### PR TITLE
feat: shared terraform plugin cache

### DIFF
--- a/terraform/.terraformrc
+++ b/terraform/.terraformrc
@@ -1,0 +1,1 @@
+plugin_cache_dir = "$HOME/.terraform.d/plugin-cache"


### PR DESCRIPTION
## Summary
- Adds `terraform` stow package with `.terraformrc` that sets `plugin_cache_dir`
- All Terraform workspaces will symlink providers from `~/.terraform.d/plugin-cache` instead of each downloading their own copy
- Saves ~25 GB on disk for repos like `internal-infra` with many independent workspaces

## Notes
- Existing `.terraform/` dirs need a `rm -rf .terraform && terraform init` to start using the shared cache
- `$HOME` is used (not `~`) because Terraform doesn't expand tilde in HCL config values