### PR TITLE
docs(claude): sharpen squash-merge branch-staleness guidance

### DIFF
--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -20,7 +20,7 @@ The following are a list of rules and preferences that must be followed. Excepti
 
 ## Git
 
-Repos in GitHub orgs `tractorbeamai/` and `wadefletch/` (in local folders `~/Developer/Tractorbeam/` and `~/Developer/`) maintain a linear history on main. Strongly prefer squash merge (most cases) or rebase merge (when the PR has meticulous, meaningful commits) over merge commits.
+My GitHub username is `wadefletch`. Repos in GitHub orgs `tractorbeamai/` and `wadefletch/` (in local folders `~/Developer/Tractorbeam/` and `~/Developer/`) maintain a linear history on main. Strongly prefer squash merge (most cases) or rebase merge (when the PR has meticulous, meaningful commits) over merge commits.
 
 Squash merges break SHA- and patch-id-based comparisons — `git branch --merged`, `git cherry -v`, and three-dot `git diff main...<branch>` all falsely flag already-merged branches as unique. Use two-dot `git diff main..<branch>`: zero lines means fully merged. When non-empty, also diff the reverse (`<branch>..main`) — opposing changes in the same sections mean main superseded the branch via a different PR. Grepping main's log for the branch's commit titles is a fast first check.
 

--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -20,7 +20,9 @@ The following are a list of rules and preferences that must be followed. Excepti
 
 ## Git
 
-Repos in GitHub orgs `tractorbeamai/` and `wadefletch/` (in local folders `~/Developer/Tractorbeam/` and `~/Developer/`) maintain a linear history on main. Strongly prefer squash merge (most cases) or rebase merge (when the PR has meticulous, meaningful commits) over merge commits. Because we squash merge, commit hashes on feature branches won't match main — when checking if a branch is stale/merged, compare actual diffs (`git diff main...<branch>`) rather than relying on commit SHAs or `git branch --merged`.
+Repos in GitHub orgs `tractorbeamai/` and `wadefletch/` (in local folders `~/Developer/Tractorbeam/` and `~/Developer/`) maintain a linear history on main. Strongly prefer squash merge (most cases) or rebase merge (when the PR has meticulous, meaningful commits) over merge commits.
+
+Squash merges break SHA- and patch-id-based comparisons — `git branch --merged`, `git cherry -v`, and three-dot `git diff main...<branch>` all falsely flag already-merged branches as unique. Use two-dot `git diff main..<branch>`: zero lines means fully merged. When non-empty, also diff the reverse (`<branch>..main`) — opposing changes in the same sections mean main superseded the branch via a different PR. Grepping main's log for the branch's commit titles is a fast first check.
 
 ## Linear
 


### PR DESCRIPTION
## Summary

Rewrites the squash-merge section of the global Claude CLAUDE.md to give actionable tests for branch staleness.

Motivating case: I was misled by three-dot `git diff main...<branch>` on a Tractorbeam repo with many squash-merged branches — it showed large diffs on branches whose content was already on main, and I re-pushed two stale branches before catching it. Two-dot diff + reverse diff + title grep would have caught it immediately.

## Changes
- Calls out which tools are broken by squash merges (`git branch --merged`, `git cherry -v`, three-dot diff)
- Prescribes two-dot `git diff main..<branch>` as the primary test
- Adds reverse diff technique for spotting *superseded* (not merged) branches — where main has conflicting changes that indicate the branch was abandoned in favor of a different PR
- Adds title-grep as a fast heuristic

## Test plan
- [x] Rule applied correctly to `feat/terraform-plugin-cache` locally — identified that the terraform commit was already merged via PR #4 despite `git cherry -v` reporting otherwise