### PR TITLE
feat(zsh): add punch function for Tailscale NAT hole punch

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -116,6 +116,24 @@ stopall() {
 }
 
 
+# Trigger arrakis -> corrino tailscale ping via Fleet, forcing NAT hole
+# punch. Hard NAT at the office means corrino can't initiate directly; if
+# arrakis sends first, both sides become reachable. Token lives in login
+# keychain (service: fleet-api-token).
+punch() {
+  local target="${1:-corrino}"
+  local token
+  token=$(security find-generic-password -a "$USER" -s "fleet-api-token" -w 2>/dev/null) || {
+    echo "punch: no fleet-api-token in keychain (security add-generic-password -a \$USER -s fleet-api-token -w ...)" >&2
+    return 1
+  }
+  local script='/Applications/Tailscale.app/Contents/MacOS/Tailscale ping --c 3 --timeout 3s '"$target"
+  curl -sS -H "Authorization: Bearer $token" -H "Content-Type: application/json" \
+    -X POST "https://fleet.tractorbeam.ai/api/latest/fleet/scripts/run/sync" \
+    --data "{\"host_id\": 3, \"script_contents\": \"$script\"}" \
+    | jq -r '.output // .errors'
+}
+
 # Automatically squash-merge PR after all checks pass
 automerge() {
   gh pr checks $1 --watch && gh pr merge $1 --squash --delete-branch


### PR DESCRIPTION
## Summary
- Adds a `punch` shell function that triggers `tailscale ping <target>` on arrakis via the Fleet scripts API
- The office Meraki MX75 is a hard/symmetric NAT, so corrino can't initiate direct connections to arrakis — but if arrakis sends first, the hole opens both ways
- Fleet API token is read from the macOS login keychain (service `fleet-api-token`) rather than an env var

## Test plan
- [ ] `security add-generic-password -a $USER -s fleet-api-token -w <token>` once
- [ ] `punch` from corrino → arrakis pings corrino via Fleet → subsequent `tailscale ssh arrakis` from corrino works without needing to wait