### PR TITLE
chore(cursor): small settings cleanup

### DIFF
--- a/cursor/Library/Application Support/Cursor/User/keybindings.json
+++ b/cursor/Library/Application Support/Cursor/User/keybindings.json
@@ -18,10 +18,5 @@
         "text": "\\\r\n"
     },
     "when": "terminalFocus"
-},
-{
-  "key": "alt+cmd+s",
-  "command": "workbench.action.toggleUnifiedSidebarFromKeyboard",
-  "when": "!isAuxiliaryWindowFocusedContext"
 }
 ]

--- a/cursor/Library/Application Support/Cursor/User/settings.json
+++ b/cursor/Library/Application Support/Cursor/User/settings.json
@@ -14,7 +14,6 @@
     },
     "editor.defaultFormatter": "charliermarsh.ruff",
   },
-  "breadcrumbs.enabled": false,
   "cSpell.enabled": false,
   "cSpell.userWords": ["Tractorbeam"],
   "cursor.composer.shouldChimeAfterChatFinishes": true,
@@ -191,4 +190,5 @@
   "claudeCode.selectedModel": "default",
   "terraform.languageServer.enable": true,
   "cursorpyright.analysis.autoImportCompletions": true,
+  "update.mode": "silentlyApplyOnQuit",
 }


### PR DESCRIPTION
## Summary
- Remove unused `alt+cmd+s` keybinding for the aux sidebar toggle
- Drop the `breadcrumbs.enabled: false` override (defaulting to on)
- Set `update.mode: silentlyApplyOnQuit` so Cursor applies updates on quit instead of nagging

## Test plan
- [ ] Reload Cursor, confirm breadcrumbs visible and no update prompt