### PR TITLE
fix: make dotfiles work on Linux (Coder workspaces)

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,7 +5,7 @@ DOTFILES="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OS="$(uname -s)"
 
 # macOS-only stow packages (contain Library/ paths or macOS-only tools)
-MACOS_ONLY="cursor duti nightly-maintenance vscode"
+MACOS_ONLY="cursor duti nightly-maintenance vscode wallpapers"
 
 # CLI packages to install (must exist in brew + apt/dnf/yum/pacman)
 PACKAGES=(git neovim tmux stow)

--- a/git/.config/git/config
+++ b/git/.config/git/config
@@ -1,7 +1,7 @@
 [user]
 name = wadefletch
 email = wbfletch@gmail.com
-signingkey = /Users/wadefletcher/.ssh/id_github_wadefletch.pub
+signingkey = ~/.ssh/id_github_wadefletch.pub
 
 [core]
 editor = nvim
@@ -16,7 +16,7 @@ autoSetupRemote = true
 format = ssh
 
 [gpg "ssh"]
-allowedSignersFile = /Users/wadefletcher/.config/git/allowed_signers
+allowedSignersFile = ~/.config/git/allowed_signers
 
 [commit]
 gpgsign = true
@@ -32,10 +32,10 @@ ff = only
 
 [credential "https://github.com"]
 	helper =
-	helper = !/opt/homebrew/bin/gh auth git-credential
+	helper = !gh auth git-credential
 [credential "https://gist.github.com"]
 	helper =
-	helper = !/opt/homebrew/bin/gh auth git-credential
+	helper = !gh auth git-credential
 
 [includeIf "gitdir:~/Developer/Tractorbeam/client-carlyle/"]
 	path = ~/.config/git/gitconfig-carlyle

--- a/ssh/.ssh/authorized_keys
+++ b/ssh/.ssh/authorized_keys
@@ -1,1 +1,0 @@
-ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJgZKe2zkJoY4y5cqrehvLMwDRr2E7f/XQNg22/vwWiy wbfletch@gmail.com


### PR DESCRIPTION
## Summary
- Audited the repo against [Coder's dotfiles flow](https://coder.com/docs/user-guides/workspace-dotfiles), which clones the repo into a workspace (Ubuntu 24.04 in our case) and runs `bootstrap.sh`.
- `bootstrap.sh` already handles Linux, but a few things broke once stow ran.

## Changes
- **git config**: replaced hardcoded `/Users/wadefletcher/...` paths with `~` and dropped the `/opt/homebrew/bin/` prefix from the `gh` credential helper. Without this, `commit.gpgsign = true` fails on Linux (signing key path doesn't exist) and HTTPS git operations fail (no `/opt/homebrew/bin/gh`).
- **ssh**: removed `ssh/.ssh/authorized_keys` from the stow package. Coder injects its own `~/.ssh/authorized_keys` to enable workspace SSH; stowing ours either errors on conflict or clobbers Coder's keys.
- **bootstrap**: added `wallpapers` to `MACOS_ONLY` so the loose jpg doesn't get symlinked into `$HOME` on Linux.

## Test plan
- [ ] Re-run `./bootstrap.sh` on macOS — no behavior change (paths resolve identically, `wallpapers` was already stowed and remains so).
- [ ] Spin up a Coder workspace pointing at this repo and confirm `git commit -S` works and no stray `~/iridescence-*.jpg` symlink appears.