### PR TITLE
fix(bootstrap): install starship without sudo

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -120,7 +120,13 @@ install_deps() {
     ok "starship already installed"
   else
     info "installing starship"
-    curl -sS https://starship.rs/install.sh | sh -s -- -y
+    # Install into a user-writable bin dir so the upstream installer skips
+    # its `sudo -v` priming step. `sudo -v` requires a real password even
+    # under NOPASSWD: ALL (validation has no target command for the rule
+    # to match), and Coder's `coder` user has a locked account, so the
+    # default install path hangs on an unanswerable prompt.
+    mkdir -p "$HOME/.local/bin"
+    curl -sS https://starship.rs/install.sh | sh -s -- -y -b "$HOME/.local/bin"
     ok "starship"
   fi
 


### PR DESCRIPTION
## Summary

- The upstream starship installer calls `sudo -v` upfront, which requires PAM password auth even when `NOPASSWD: ALL` is set (validate has no target command for the NOPASSWD rule to match).
- Coder workspaces run as the `coder` user with a locked password, so the prompt is unanswerable and `bootstrap.sh` hangs there during dotfiles install.
- Pass `-b $HOME/.local/bin` so the installer drops the binary in a user-writable path and skips its `elevate_priv()` step entirely. No sudo, no prompt. Works on macOS too — `~/.local/bin` is harmless there.

## Test Plan

- [ ] Run `coder dotfiles https://github.com/wadefletch/dotfiles.git` from a Coder workspace shell — completes without sudo prompt, `starship --version` works after.