### PR TITLE
fix(bootstrap): stow target + login shell on Coder

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -139,6 +139,18 @@ install_deps() {
     ok "claude code"
   fi
 
+  # Switch login shell to zsh. Stowed config only loads if zsh is the
+  # actual login shell, but apt/brew installing zsh doesn't change that.
+  # On Coder workspaces `coder`'s password is locked, so chsh needs sudo.
+  if command -v zsh &>/dev/null && [[ "${SHELL:-}" != *"/zsh" ]]; then
+    zsh_path="$(command -v zsh)"
+    if ! grep -qx "$zsh_path" /etc/shells 2>/dev/null; then
+      echo "$zsh_path" | sudo tee -a /etc/shells >/dev/null
+    fi
+    sudo chsh -s "$zsh_path" "$USER"
+    ok "default shell -> zsh (relog to take effect)"
+  fi
+
   # macOS GUI apps
   if [[ "$OS" == "Darwin" ]]; then
     for app in "${CASKS[@]}"; do
@@ -178,7 +190,12 @@ stow_packages() {
       continue
     fi
 
-    stow --restow "$pkg"
+    # Pin target to $HOME. Stow's default target is the parent of the stow
+    # dir, which works when this repo is cloned at ~/dotfiles but not when
+    # it's elsewhere — e.g. Coder's dotfiles module clones to
+    # ~/.config/coderv2/dotfiles, which would dump symlinks into
+    # ~/.config/coderv2/ instead of $HOME.
+    stow -t "$HOME" --restow "$pkg"
     ok "$pkg"
   done
 }


### PR DESCRIPTION
## Summary

Fixes two issues that show up when running `bootstrap.sh` via Coder's dotfiles module (which clones to `~/.config/coderv2/dotfiles` rather than `~/dotfiles`).

## Changes

- **Pin stow target to `$HOME`.** Stow's default target is the parent of the stow dir. That's `~` when this repo lives at `~/dotfiles`, but `~/.config/coderv2/` when Coder's dotfiles module owns the clone — so `.zshrc`, `.zshenv`, `.config/git/`, etc. all symlinked into the wrong place. `stow -t "$HOME"` makes it location-independent.
- **chsh to zsh.** Apt/brew installing the zsh package doesn't make it the login shell, and stowed zsh config never loads while `$SHELL` is still bash. Idempotent (no-ops once you're already on zsh). Uses `sudo chsh` because Coder's `coder` account is locked-password.

## Test Plan

- [ ] Re-run `coder dotfiles https://github.com/wadefletch/dotfiles.git` on a Coder workspace; afterward `~/.zshrc` exists, `getent passwd coder` ends in `/bin/zsh`, new shell loads starship prompt.
- [ ] On macOS where the repo lives at `~/dotfiles`, behavior is unchanged (stow target is already `~`; `$SHELL` already zsh, so chsh block skips).