### PR TITLE
fix(claude): anchor stow-ignore patterns to package root

### DIFF
--- a/claude/.stow-local-ignore
+++ b/claude/.stow-local-ignore
@@ -1,4 +1,4 @@
-CLAUDE\.md
-inventory\.md
-claude-plugin-refresh\.sh
+^/CLAUDE\.md$
+^/inventory\.md$
+^/claude-plugin-refresh\.sh$
 \.claude/references


### PR DESCRIPTION
## Summary

`claude/.stow-local-ignore` was using unanchored regexes. `CLAUDE\.md` matches the basename anywhere in the tree, so stow was silently skipping both the package-meta `claude/CLAUDE.md` (correct) **and** the nested `claude/.claude/CLAUDE.md` (incorrect — that's the Claude Code global config that needs to land at `~/.claude/CLAUDE.md`).

## Changes

- Anchor `^/CLAUDE\.md$`, `^/inventory\.md$`, `^/claude-plugin-refresh\.sh$` so they only match at the package root.
- Leave `\.claude/references` as-is (intentionally path-based).

## Test Plan

- [ ] On a workspace with the previous (broken) state, re-stow: `cd ~/.config/coderv2/dotfiles && stow -t "$HOME" -R claude` — afterward `~/.claude/CLAUDE.md` is a symlink, while `~/CLAUDE.md` and `~/inventory.md` do not appear.