### PR TITLE
perf(zsh): consolidate node/python on mise, fix slow rustup check

### DIFF
--- a/ghostty/.config/ghostty/config
+++ b/ghostty/.config/ghostty/config
@@ -12,6 +12,7 @@ background-opacity = "0.95"
 background-blur-radius = "10"
 window-padding-x = "10"
 window-padding-y = "10"
+cursor-style = "bar"
 
 # macos-specific aesthetics
 macos-icon = "xray"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -3,21 +3,14 @@ if command -v nvim &> /dev/null; then
   export EDITOR="nvim"
 fi
 
-# Pyenv (Python)
-if command -v pyenv &> /dev/null; then
-  export PYENV_ROOT="$HOME/.pyenv"
-  [[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"
-  eval "$(pyenv init - zsh)"
+# Mise (Node, Python, and other dev tools)
+if command -v mise &> /dev/null; then
+  eval "$(mise activate zsh)"
 fi
 
-# NVM (Node)
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh"  # This loads nvm
-[ -s "$NVM_DIR/bash_completion" ] && source "$NVM_DIR/bash_completion"
-
 # Rustup (Rust)
-if command -v brew &> /dev/null && brew list rustup &>/dev/null; then
-  export PATH="$(brew --prefix rustup)/bin:$PATH"
+if [[ -d "/opt/homebrew/opt/rustup/bin" ]]; then
+  export PATH="/opt/homebrew/opt/rustup/bin:$PATH"
 fi
 
 # AWS CLI


### PR DESCRIPTION
## Summary

- Replaces eager pyenv + NVM init with `mise activate zsh` (mise was already used for dev tools like terraform/terramate/actionlint, just not node/python)
- Replaces `brew list rustup` + `brew --prefix rustup` (two subprocess calls costing ~550ms) with a static `/opt/homebrew/opt/rustup/bin` directory check

## Impact

Interactive zsh startup: **1.4s → 82ms** (~17x faster).

zprof breakdown of what was killing it:
- NVM (`nvm.sh` + `bash_completion` triggering `compinit`) — ~470ms / 56% of total
- `brew list rustup` + `brew --prefix rustup` — ~550ms
- `pyenv init - zsh` — ~155ms

mise resolves node/python via shims, no init-time work.

## Test plan

- [x] `time zsh -i -c exit` → 82ms (was 1.4s)
- [x] `node --version` resolves (v22.22.2 via mise)
- [x] `python --version` resolves (3.13.13 via mise)
- [x] `which node` / `which python` point at mise installs
- [ ] Open a fresh terminal and confirm prompt loads instantly
- [ ] `cargo --version` still works (rustup path)