### PR TITLE
fix(bootstrap): install zsh on Linux so chsh actually runs

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -8,7 +8,7 @@ OS="$(uname -s)"
 MACOS_ONLY="cursor duti nightly-maintenance vscode wallpapers"
 
 # CLI packages to install (must exist in brew + apt/dnf/yum/pacman)
-PACKAGES=(git neovim stow)
+PACKAGES=(git neovim stow zsh)
 
 # macOS GUI apps (brew casks)
 CASKS=(cursor ghostty docker)


### PR DESCRIPTION
## Summary

Adds `zsh` to the `PACKAGES` array in [bootstrap.sh](bootstrap.sh) so it gets installed on Linux hosts that ship bash-only (Amazon Linux, vanilla Ubuntu, etc.).

## The bug

The chsh block guards on `command -v zsh`:

\`\`\`bash
if command -v zsh &>/dev/null && [[ "\${SHELL:-}" != *"/zsh" ]]; then
\`\`\`

When zsh isn't installed, this fails silently — no error, no log line, login shell stays bash.

macOS bootstraps fine today because \`/bin/zsh\` ships with the OS.

## Behavior on each platform after the fix

- **macOS**: \`command -v zsh\` finds \`/bin/zsh\` → \`pkg_install\` is skipped. System zsh stays as the chsh target.
- **Linux (apt/dnf/yum/pacman)**: zsh missing → installed via package manager → chsh block runs.

## Test plan

- [ ] Run on a fresh bash-default EC2 → login shell flips to zsh after re-login
- [ ] Re-run on macOS → no-op for zsh (still uses /bin/zsh)