### PR TITLE
feat(mise): stow global config and bootstrap mise tools

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 DOTFILES="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OS="$(uname -s)"
 
+# Ensure curl-installed tools (starship, mise) are findable later in this
+# script. .zshenv adds this for interactive shells, but we run as bash.
+export PATH="$HOME/.local/bin:$PATH"
+
 # macOS-only stow packages (contain Library/ paths or macOS-only tools)
 MACOS_ONLY="cursor duti nightly-maintenance vscode wallpapers"
 
@@ -139,6 +143,20 @@ install_deps() {
     ok "claude code"
   fi
 
+  # mise (manages node/python/etc. per the stowed ~/.config/mise/config.toml).
+  # Linux distros don't reliably package it, so use the upstream installer
+  # which lands at ~/.local/bin/mise.
+  if command -v mise &>/dev/null; then
+    ok "mise already installed"
+  else
+    info "installing mise"
+    case "$OS" in
+      Darwin) brew install mise ;;
+      Linux)  curl -fsSL https://mise.run | sh ;;
+    esac
+    ok "mise"
+  fi
+
   # Switch login shell to zsh. Stowed config only loads if zsh is the
   # actual login shell, but apt/brew installing zsh doesn't change that.
   # On Coder workspaces `coder`'s password is locked, so chsh needs sudo.
@@ -222,6 +240,14 @@ main() {
   install_deps
   stow_packages
   setup_hooks
+
+  # Install everything declared in the stowed mise config (node, python, …).
+  # Must run after stow_packages so the symlinked config is in place.
+  if command -v mise &>/dev/null; then
+    info "installing mise tools"
+    mise install
+    ok "mise tools"
+  fi
 
   if [[ "$OS" == "Darwin" ]] && command -v duti &>/dev/null; then
     info "applying default app associations"

--- a/mise/.config/mise/config.toml
+++ b/mise/.config/mise/config.toml
@@ -1,0 +1,3 @@
+[tools]
+node = "22"
+python = "3.13"


### PR DESCRIPTION
## Summary

Pins the global mise toolchain (node 22, python 3.13) in the dotfiles repo and teaches bootstrap.sh to install mise + materialize its tools, so a fresh EC2 ends up with the same node/python as macOS.

## Why

Today on a fresh Coder/EC2 box: bootstrap installs zsh + starship, the `.zshrc` calls `mise activate zsh`, but **nothing is installed in mise** because the global config only existed on my Mac. Result: starship's `nodejs`/`python` modules show nothing, `node` / `python` not found.

## Changes

- **new stow package `mise/`** — the global config that was floating in `~/.config/mise/` is now in the repo:
  ```toml
  [tools]
  node = "22"
  python = "3.13"
  ```
- **bootstrap.sh**:
  - prepend `~/.local/bin` to `PATH` so curl-installed tools (starship, mise) are findable later in the script
  - install mise — `brew install mise` on macOS, `curl https://mise.run | sh` on Linux
  - after stow runs, call `mise install` to install everything declared in the now-symlinked config

## Test plan

- [ ] On EC2: pull this branch, run `bootstrap.sh` → `node --version` and `python --version` work
- [ ] On macOS: re-run `bootstrap.sh` → no-op for mise (already installed), `mise install` is idempotent