### PR TITLE
chore(claude): tune plugin set and gitignore references dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 **/settings.local.json
 claude/.claude/memory/
+claude/.claude/references/
 superwhisper/Documents/superwhisper/recordings/
 obsidian-web-clipper-settings.json

--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -302,15 +302,17 @@
       "Write(~/.claude/references/**)",
       "NotebookEdit(~/.claude/references/**)"
     ],
-    "additionalDirectories": ["~/.claude/references"]
+    "additionalDirectories": [
+      "~/.claude/references"
+    ]
   },
   "statusLine": {
     "type": "command",
     "command": "~/.claude/statusline.sh"
   },
   "enabledPlugins": {
-    "code-simplifier@claude-plugins-official": true,
-    "context7@claude-plugins-official": true,
+    "code-simplifier@claude-plugins-official": false,
+    "context7@claude-plugins-official": false,
     "frontend-design@claude-plugins-official": false,
     "plugin-dev@claude-plugins-official": false,
     "typescript-lsp@claude-plugins-official": true,
@@ -318,17 +320,17 @@
     "git@tractorbeam": true,
     "linear@tractorbeam": true,
     "project-updates@tractorbeam": true,
-    "brd@tractorbeam": true,
-    "references@tractorbeam": true,
-    "reflect@tractorbeam": true,
+    "brd@tractorbeam": false,
+    "references@tractorbeam": false,
+    "reflect@tractorbeam": false,
     "rtk@tractorbeam": true,
     "code-style@tractorbeam": true,
-    "optimize-dev-stack@tractorbeam": true,
+    "optimize-dev-stack@tractorbeam": false,
     "agent-browser@agent-browser": true,
-    "document-skills@anthropic-agent-skills": true,
+    "document-skills@anthropic-agent-skills": false,
     "rust-analyzer-lsp@claude-plugins-official": true,
     "writing@tractorbeam": true,
-    "documents@tractorbeam": true
+    "documents@tractorbeam": false
   },
   "extraKnownMarketplaces": {
     "tractorbeam": {
@@ -368,7 +370,10 @@
       }
     }
   },
+  "effortLevel": "medium",
   "autoUpdatesChannel": "latest",
   "skipDangerousModePermissionPrompt": true,
-  "effortLevel": "medium"
+  "theme": "light",
+  "verbose": true,
+  "preferredNotifChannel": "ghostty"
 }


### PR DESCRIPTION
## Summary
- Disable several plugins I'm not currently using (`code-simplifier`, `context7`, `brd`, `references`, `reflect`, `optimize-dev-stack`, `document-skills`, `documents`).
- Add personal settings: `theme: light`, `verbose: true`, `preferredNotifChannel: ghostty`, and reorder `effortLevel`.
- Gitignore `claude/.claude/references/` — its subdirectories are local external repo clones, not meant to be tracked.