### PR TITLE
chore: gitignore *.local.md files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 **/settings.local.json
+**/*.local.md
 claude/.claude/memory/
 claude/.claude/references/
 superwhisper/Documents/superwhisper/recordings/


### PR DESCRIPTION
## Summary
- Adds `**/*.local.md` to `.gitignore` so machine-specific `CLAUDE.local.md` and `AGENTS.local.md` files aren't committed
- Matches the existing `**/settings.local.json` convention