### PR TITLE
chore(claude): add figma plugin, sync settings, disable auto-memory

### DIFF
--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -304,6 +304,7 @@
       "Write(~/.claude/references/**)",
       "NotebookEdit(~/.claude/references/**)"
     ],
+    "defaultMode": "auto",
     "additionalDirectories": [
       "~/.claude/references"
     ]
@@ -316,7 +317,7 @@
     "code-simplifier@claude-plugins-official": false,
     "context7@claude-plugins-official": false,
     "frontend-design@claude-plugins-official": false,
-    "plugin-dev@claude-plugins-official": false,
+    "plugin-dev@claude-plugins-official": true,
     "typescript-lsp@claude-plugins-official": true,
     "interview@tractorbeam": true,
     "git@tractorbeam": true,
@@ -333,7 +334,8 @@
     "rust-analyzer-lsp@claude-plugins-official": true,
     "writing@tractorbeam": true,
     "documents@tractorbeam": false,
-    "shadcn@shadcn-ui": true
+    "shadcn@shadcn-ui": true,
+    "figma@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {
     "tractorbeam": {
@@ -368,10 +370,12 @@
       }
     }
   },
-  "effortLevel": "medium",
+  "effortLevel": "high",
   "autoUpdatesChannel": "latest",
   "skipDangerousModePermissionPrompt": true,
-  "theme": "light",
+  "theme": "auto",
   "verbose": true,
-  "preferredNotifChannel": "ghostty"
+  "preferredNotifChannel": "ghostty",
+  "skipAutoPermissionPrompt": true,
+  "autoMemoryEnabled": false
 }

--- a/claude/claude-plugin-refresh.sh
+++ b/claude/claude-plugin-refresh.sh
@@ -21,6 +21,8 @@ echo "  - frontend-design"
 claude plugin install frontend-design@claude-plugins-official
 echo "  - code-simplifier"
 claude plugin install code-simplifier@claude-plugins-official
+echo "  - figma"
+claude plugin install figma@claude-plugins-official
 echo "  - core"
 claude plugin install core@tractorbeam
 echo "  - git"


### PR DESCRIPTION
## Summary
- Enable the `figma@claude-plugins-official` plugin and track it in the dotfiles-managed config
- Sync `settings.json` with drift accumulated this session
- Disable `autoMemoryEnabled`

## Changes
- `settings.json`: add `figma@claude-plugins-official: true` to `enabledPlugins`; enable `plugin-dev`; set `defaultMode: auto`, `effortLevel: high`, `theme: auto`; add `skipAutoPermissionPrompt`, `autoMemoryEnabled: false`
- `claude-plugin-refresh.sh`: install figma alongside the other `claude-plugins-official` plugins so fresh machines pick it up