### PR TITLE
chore(nvim): bump lazyvim NEWS.md version marker

### DIFF
--- a/nvim/.config/nvim/lazyvim.json
+++ b/nvim/.config/nvim/lazyvim.json
@@ -27,7 +27,7 @@
   ],
   "install_version": 8,
   "news": {
-    "NEWS.md": "10960"
+    "NEWS.md": "11866"
   },
   "version": 8
 }


### PR DESCRIPTION
## Summary
- Sync the LazyVim `NEWS.md` version marker (`10960` → `11866`) that LazyVim updated locally after reading the latest changelog.