### PR TITLE
chore(mise): set global defaults — trust, lockfile, aggressive PATH

### DIFF
--- a/mise/.config/mise/config.toml
+++ b/mise/.config/mise/config.toml
@@ -2,3 +2,16 @@
 "cargo:sccache" = "0.15.0"
 node = "22"
 python = "3.13"
+
+[settings]
+trusted_config_paths = [
+  "~/Developer/Tractorbeam",
+  "~/Developer/wadefletch",
+]
+activate_aggressive = true
+idiomatic_version_file_enable_tools = ["node", "python"]
+lockfile = true
+minimum_release_age = "7d"
+
+[settings.python]
+compile = false


### PR DESCRIPTION
## Summary

Adds a `[settings]` block to the stowed global mise config to eliminate recurring friction across all repos.

- `trusted_config_paths = ["~/Developer/Tractorbeam", "~/Developer/wadefletch"]` — kills trust prompts on every new worktree.
- `activate_aggressive = true` — keeps mise's PATH ahead of later shell config (upstream #9925/#9994).
- `idiomatic_version_file_enable_tools = ["node", "python"]` — opts back in after the 2025.10 default-off flip.
- `lockfile = true` — makes `mise.lock` the default everywhere; per-repo lockfile commits will follow.
- `minimum_release_age = "7d"` — basic supply-chain delay.
- `python.compile = false` — use precompiled binaries.

## Test plan

- [x] `mise settings ls` shows all six new values
- [x] `mise doctor` reports no new issues
- [ ] Open a fresh shell in a newly-created worktree under `~/Developer/Tractorbeam/*` — no trust prompt