### PR TITLE
fix(nightly): sweep rust artifacts inside worktrees

### DIFF
--- a/nightly-maintenance/.local/bin/nightly-maintenance.sh
+++ b/nightly-maintenance/.local/bin/nightly-maintenance.sh
@@ -1,20 +1,57 @@
 #!/bin/zsh
 # Nightly macOS maintenance script
 
-echo "=== Nightly Maintenance: $(date) ===" >> /tmp/nightly-maintenance.log
+# launchd starts us with a bare PATH; put mise shims, Homebrew, and the
+# cargo bindir up front so brew/pnpm/cargo-sweep/git all resolve.
+export PATH="$HOME/.local/share/mise/shims:/opt/homebrew/bin:$HOME/.cargo/bin:$PATH"
+
+LOG=/tmp/nightly-maintenance.log
+CARGO_SWEEP="$HOME/.cargo/bin/cargo-sweep"
+DEVELOPER="$HOME/Developer"
+CONSTELLATION="$DEVELOPER/Tractorbeam/constellation"
+
+echo "=== Nightly Maintenance: $(date) ===" >> "$LOG"
 
 # Homebrew update and cleanup
-echo "Updating Homebrew..." >> /tmp/nightly-maintenance.log
-/opt/homebrew/bin/brew update >> /tmp/nightly-maintenance.log 2>&1
-/opt/homebrew/bin/brew upgrade >> /tmp/nightly-maintenance.log 2>&1
-/opt/homebrew/bin/brew cleanup --prune=all >> /tmp/nightly-maintenance.log 2>&1
+echo "Updating Homebrew..." >> "$LOG"
+brew update >> "$LOG" 2>&1
+brew upgrade >> "$LOG" 2>&1
+brew cleanup --prune=all >> "$LOG" 2>&1
 
-# pnpm store prune
-echo "Pruning pnpm store..." >> /tmp/nightly-maintenance.log
-/opt/homebrew/bin/pnpm store prune >> /tmp/nightly-maintenance.log 2>&1
+# pnpm store prune (pnpm is mise-managed; skip cleanly if no global shim)
+echo "Pruning pnpm store..." >> "$LOG"
+if command -v pnpm >/dev/null 2>&1; then
+  pnpm store prune >> "$LOG" 2>&1
+else
+  echo "pnpm not on PATH, skipping store prune" >> "$LOG"
+fi
 
-# Cargo sweep (remove Rust artifacts older than 30 days)
-echo "Running cargo sweep..." >> /tmp/nightly-maintenance.log
-/Users/wadefletcher/.cargo/bin/cargo-sweep sweep --time 30 --recursive /Users/wadefletcher/Developer >> /tmp/nightly-maintenance.log 2>&1
+# Drop the rust/target of any constellation worktree whose branch is fully
+# merged into main. Two-dot `origin/main..<branch>` is empty only when the
+# branch carries nothing main lacks; squash-merges past which main has moved
+# read as non-empty, so this never deletes an unmerged worktree's artifacts
+# (the time-based sweep below reclaims those).
+echo "Reclaiming merged constellation worktree targets..." >> "$LOG"
+if [ -d "$CONSTELLATION" ]; then
+  (
+    cd "$CONSTELLATION" || exit 0
+    git fetch --quiet origin main 2>/dev/null
+    git worktree list --porcelain | awk '/^worktree /{print $2}' | while read -r wt; do
+      [ -d "$wt/rust/target" ] || continue
+      br=$(git -C "$wt" rev-parse --abbrev-ref HEAD 2>/dev/null)
+      { [ -z "$br" ] || [ "$br" = "main" ]; } && continue
+      if [ -z "$(git -C "$wt" diff --name-only "origin/main..$br" 2>/dev/null)" ]; then
+        echo "  merged: removing $wt/rust/target" >> "$LOG"
+        rm -rf "$wt/rust/target"
+      fi
+    done
+  )
+fi
 
-echo "=== Maintenance complete ===" >> /tmp/nightly-maintenance.log
+# Sweep rust artifacts unused for 14 days across every project under Developer.
+# --hidden is load-bearing: worktrees live under .claude/worktrees, and the
+# recursive walk skips dot-directories without it.
+echo "Running cargo sweep..." >> "$LOG"
+"$CARGO_SWEEP" sweep --time 14 --recursive --hidden "$DEVELOPER" >> "$LOG" 2>&1
+
+echo "=== Maintenance complete ===" >> "$LOG"


### PR DESCRIPTION
## Summary
- The nightly `cargo-sweep --recursive ~/Developer` never reclaimed anything from the directory that actually fills the disk: `cargo-sweep`'s recursive walk skips dot-directories, so it never entered `constellation/.claude/worktrees/`, where each worktree's 5–17 GB `rust/target` accumulates. They grew unbounded until the volume hit 100%.
- `--time 30` also freed nothing from active repos (artifacts were newer), and the `pnpm store prune` step pointed at `/opt/homebrew/bin/pnpm`, which no longer exists (pnpm is mise-managed) — so it errored every night.

## Changes
- Add `--hidden` to the cargo-sweep invocation so the recursive walk descends into `.claude/worktrees/` (verified: visits worktree project dirs vs 0 before).
- Tighten the sweep window from `--time 30` to `--time 14`.
- Before the sweep, drop `rust/target` for any constellation worktree whose branch is fully merged into main. Uses two-dot `origin/main..<branch>` (empty only when the branch carries nothing main lacks), so it never removes an unmerged worktree's artifacts — the time-based sweep handles those.
- Fix the dead pnpm path (skip cleanly when no pnpm shim is present).
- Front-load mise shims / Homebrew / cargo bin onto `PATH` so launchd's bare environment resolves every tool, and factor out repeated literals.