### PR TITLE
feat(bootstrap): authorize tailnet SSH key on each machine

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -258,6 +258,45 @@ setup_hooks() {
   ok "git hooks configured"
 }
 
+# --- Tailnet SSH -------------------------------------------------------------
+
+# Authorize this machine's GitHub key for passwordless host-to-host SSH across
+# the tailnet (corrino <-> arrakis). Both machines carry the same
+# id_github_wadefletch keypair, so appending its pubkey to authorized_keys lets
+# each accept the other. The keypair is intentionally not tracked in this repo,
+# so on a fresh machine it may be absent — skip gracefully rather than fail.
+setup_tailnet_ssh() {
+  local pub="$HOME/.ssh/id_github_wadefletch.pub"
+  local ak="$HOME/.ssh/authorized_keys"
+
+  if [[ ! -f "$pub" ]]; then
+    info "skipping tailnet ssh (no $pub)"
+    return
+  fi
+
+  mkdir -p "$HOME/.ssh"
+  chmod 700 "$HOME/.ssh"
+
+  # Append only if absent so repeated runs don't duplicate the entry. grep over
+  # a missing authorized_keys returns non-zero, which correctly triggers the
+  # first append.
+  if ! grep -qF "$(cat "$pub")" "$ak" 2>/dev/null; then
+    cat "$pub" >> "$ak"
+    ok "tailnet ssh key authorized"
+  else
+    ok "tailnet ssh key already authorized"
+  fi
+  chmod 600 "$ak"
+
+  # macOS needs Remote Login on to accept inbound SSH. Don't enable it here —
+  # that needs sudo and an interactive prompt — just flag it if it's off.
+  if [[ "$OS" == "Darwin" ]] && command -v systemsetup &>/dev/null; then
+    if ! systemsetup -getremotelogin 2>/dev/null | grep -qi 'On'; then
+      info "remote login is off — enable with: sudo systemsetup -setremotelogin on"
+    fi
+  fi
+}
+
 # --- Main --------------------------------------------------------------------
 
 main() {
@@ -272,6 +311,7 @@ main() {
   install_deps
   stow_packages
   setup_hooks
+  setup_tailnet_ssh
 
   # Install everything declared in the stowed mise config (node, python, …).
   # Must run after stow_packages so the symlinked config is in place.


### PR DESCRIPTION
## Summary
- Passwordless host-to-host SSH between the tailnet Macs (corrino <-> arrakis) only worked one direction, because only one machine had the shared `id_github_wadefletch` pubkey in its `~/.ssh/authorized_keys`. Bootstrap now authorizes it on every machine so each accepts the other.

## Changes
- Add `setup_tailnet_ssh()` and call it from `main()` (after `setup_hooks`):
  - Appends `~/.ssh/id_github_wadefletch.pub` to `~/.ssh/authorized_keys` only if not already present (idempotent), creating the file with correct perms (`~/.ssh` 700, `authorized_keys` 600).
  - Skips gracefully when the keypair is absent — it is intentionally not tracked in this repo, so a fresh machine may not have it.
  - On macOS, warns (does not enable) when Remote Login is off, since enabling it needs interactive sudo.

## Context
The `authorized_keys` file briefly lived in the repo (added in the tailnet-SSH commit, removed by the "make dotfiles work on Linux" PR) and the deployed copy was placed manually on only one host, so the reverse direction was never set up. Doing this in bootstrap keeps both machines symmetric without committing key material.