### PR TITLE
fix(bootstrap): correct macOS Remote Login detection

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -290,8 +290,12 @@ setup_tailnet_ssh() {
 
   # macOS needs Remote Login on to accept inbound SSH. Don't enable it here —
   # that needs sudo and an interactive prompt — just flag it if it's off.
+  # Reading the status also needs admin: run non-root, systemsetup prints an
+  # "administrator access" error to stderr and nothing to stdout, so match the
+  # explicit "Remote Login: Off" on combined output rather than the absence of
+  # "On" (which false-positives on the permission error).
   if [[ "$OS" == "Darwin" ]] && command -v systemsetup &>/dev/null; then
-    if ! systemsetup -getremotelogin 2>/dev/null | grep -qi 'On'; then
+    if [[ "$(systemsetup -getremotelogin 2>&1)" == *"Remote Login: Off"* ]]; then
       info "remote login is off — enable with: sudo systemsetup -setremotelogin on"
     fi
   fi


### PR DESCRIPTION
## Summary
- `setup_tailnet_ssh` warned that Remote Login was off on machines where it was actually on (confirmed on both corrino and arrakis).

## Root cause
- `systemsetup -getremotelogin` requires admin. Run non-root (the normal bootstrap case) it prints `You need administrator access to run this tool... exiting!` to **stdout** and exits 0. None of that contains "on", so `systemsetup -getremotelogin 2>/dev/null | grep -qi 'On'` saw a non-matching line and reported Remote Login off regardless of the real state.

## Fix
- Match the explicit `"Remote Login: Off"` substring on **combined** output (`2>&1`) instead of inferring off from the absence of "On". The permission error doesn't contain that string, so it no longer false-positives. Net effect: when bootstrap can't read the status (non-root), it stays silent; it only warns when it can confirm off.