### PR TITLE
feat(claude): show clear-context prompt on plan accept

### DIFF
--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -370,12 +370,13 @@
       }
     }
   },
-  "effortLevel": "auto",
   "autoUpdatesChannel": "latest",
   "autoMemoryEnabled": false,
   "skipDangerousModePermissionPrompt": true,
   "theme": "auto",
   "verbose": true,
   "preferredNotifChannel": "ghostty",
-  "skipAutoPermissionPrompt": true
+  "skipAutoPermissionPrompt": true,
+  "agentPushNotifEnabled": true,
+  "showClearContextOnPlanAccept": true
 }


### PR DESCRIPTION
## Summary
- Enable `showClearContextOnPlanAccept` in Claude Code settings so the clear-context prompt is offered when a plan is accepted.