### PR TITLE
fix(ssh): load signing key from Keychain, scope keychain opts cross-platform

### DIFF
--- a/ssh/.ssh/config
+++ b/ssh/.ssh/config
@@ -1,10 +1,13 @@
 # Must be before any Host blocks
 Include ~/.orbstack/ssh/config
 
-Host *github*
-  UseKeychain yes
-  ForwardAgent yes
+Host *
   AddKeysToAgent yes
+  IgnoreUnknown UseKeychain
+  UseKeychain yes
+
+Host *github*
+  ForwardAgent yes
   IdentityFile ~/.ssh/id_github_wadefletch
 
 Host proxmox

--- a/zsh/.zprofile
+++ b/zsh/.zprofile
@@ -1,1 +1,7 @@
 source ~/.orbstack/shell/init.zsh 2>/dev/null || :
+
+# macOS: load SSH keys from the login Keychain into the agent so signed
+# commits and pushes never prompt for a passphrase.
+if [[ "$OSTYPE" == darwin* ]]; then
+  ssh-add --apple-load-keychain --apple-use-keychain 2>/dev/null
+fi


### PR DESCRIPTION
## Summary
Fixes the recurring "Load key ... incorrect passphrase" / "failed to write commit object" failures when signing commits.

Root cause: the passphrase-protected signing key was never persisted in the macOS Keychain and nothing loaded it into a keychain-backed agent, so signing depended on incidental agent state. The `UseKeychain`/`AddKeysToAgent` directives were also scoped to `Host *github*`, which only fires on SSH connections — commit signing (`ssh-keygen -Y sign`) never reads ssh config Host blocks. The fallback workaround (`eval $(ssh-agent -s)`) spawned orphan agents whose `/tmp/ssh-*` sockets were inherited and then died.

## Changes
- `ssh/.ssh/config`: move `AddKeysToAgent yes` / `UseKeychain yes` to a global `Host *` block. `IgnoreUnknown UseKeychain` guards the macOS-only option so Linux (Coder workspaces) ignores it instead of erroring on parse.
- `zsh/.zprofile`: load Keychain-stored SSH keys into the agent at login, guarded by `[[ "$OSTYPE" == darwin* ]]` so the Apple-only `--apple-*` flags never run on Linux.

One-time setup already done on this machine: `ssh-add --apple-use-keychain ~/.ssh/id_github_wadefletch` (stores the passphrase in Keychain). New machines need this once.

## Test Plan
- [ ] After merging and `stow`-ing, open a fresh login shell and run `ssh-add -l` — the signing key should be listed without any prompt.