### PR TITLE
chore(claude): remove writing plugin

### DIFF
--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -332,7 +332,6 @@
     "agent-browser@agent-browser": true,
     "document-skills@anthropic-agent-skills": false,
     "rust-analyzer-lsp@claude-plugins-official": true,
-    "writing@tractorbeam": true,
     "documents@tractorbeam": false,
     "shadcn@shadcn-ui": true,
     "figma@claude-plugins-official": true

--- a/claude/claude-plugin-refresh.sh
+++ b/claude/claude-plugin-refresh.sh
@@ -31,8 +31,6 @@ echo "  - linear"
 claude plugin install linear@tractorbeam
 echo "  - reflect"
 claude plugin install reflect@tractorbeam
-echo "  - writing"
-claude plugin install writing@tractorbeam
 echo "  - documents"
 claude plugin install documents@tractorbeam
 


### PR DESCRIPTION
## Summary
- Removes the `writing@tractorbeam` plugin from the Claude config

## Changes
- `claude/claude-plugin-refresh.sh` — drop the `writing@tractorbeam` install step
- `claude/.claude/settings.json` — remove the `writing@tractorbeam` enabled-plugins entry