### PR TITLE
feat(claude): enable turboreview plugin at user scope

### DIFF
--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -322,6 +322,7 @@
     "reflect@tractorbeam": false,
     "code-style@tractorbeam": true,
     "optimize-dev-stack@tractorbeam": false,
+    "turboreview@tractorbeam": true,
     "agent-browser@agent-browser": true,
     "document-skills@anthropic-agent-skills": false,
     "rust-analyzer-lsp@claude-plugins-official": true,


### PR DESCRIPTION
## Summary
- Enables `turboreview@tractorbeam` in user-scope Claude settings (`claude/.claude/settings.json`).
- The `tractorbeam` marketplace is already declared in `extraKnownMarketplaces`, so this is just the enable flag — Claude Code installs the plugin from the marketplace on next session.

## What it adds
`turboreview` runs three parallel diff-scoped review subagents and synthesizes the findings:
- `review-subagent` — correctness/security branch audit
- `review-code-quality-subagent` — maintainability/structure
- `review-best-practices-subagent` — docs/idiom consistency (via ctx7/gh/web)