### PR TITLE
feat(claude): enable mise@tractorbeam plugin

### DIFF
--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -323,6 +323,7 @@
     "code-style@tractorbeam": true,
     "optimize-dev-stack@tractorbeam": false,
     "turboreview@tractorbeam": true,
+    "mise@tractorbeam": true,
     "agent-browser@agent-browser": true,
     "document-skills@anthropic-agent-skills": false,
     "rust-analyzer-lsp@claude-plugins-official": true,


### PR DESCRIPTION
## Summary
- Enables the new `mise@tractorbeam` plugin (tractorbeamai/skills#117, merged) in global Claude Code settings.

## Why
The plugin's `SessionStart` hook prepends mise's shims dir to PATH so repo-pinned tools (cargo/pnpm/node/buf/uv) resolve to the right version in the Bash tool's non-interactive shells — across the main checkout and every worktree — without a `mise exec --` wrapper. The `tractorbeam` marketplace is already registered in `extraKnownMarketplaces`.