### PR TITLE
feat: add window management dotfiles

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -9,13 +9,16 @@ OS="$(uname -s)"
 export PATH="$HOME/.local/bin:$PATH"
 
 # macOS-only stow packages (contain Library/ paths or macOS-only tools)
-MACOS_ONLY="cursor duti nightly-maintenance vscode wallpapers"
+MACOS_ONLY="cursor duti nightly-maintenance sketchybar skhd-zig vscode wallpapers yabai"
+
+# macOS-only Homebrew taps
+MACOS_TAPS=(felixkratz/formulae koekeishiya/formulae)
 
 # CLI packages to install (must exist in brew + apt/dnf/yum/pacman)
 PACKAGES=(git neovim stow zsh)
 
-# macOS GUI apps (brew casks)
-CASKS=(cursor ghostty)
+# macOS apps and fonts (brew casks)
+CASKS=(cursor ghostty font-sketchybar-app-font)
 
 info()  { printf '  [ .. ] %s\n' "$1"; }
 ok()    { printf '  [ OK ] %s\n' "$1"; }
@@ -176,6 +179,16 @@ install_deps() {
 
   # macOS GUI apps
   if [[ "$OS" == "Darwin" ]]; then
+    for tap in "${MACOS_TAPS[@]}"; do
+      if brew tap | grep -qx "$tap"; then
+        ok "$tap already tapped"
+      else
+        info "tapping $tap"
+        brew tap "$tap"
+        ok "$tap"
+      fi
+    done
+
     installed_casks="$(brew list --cask -1 2>/dev/null)"
     for app in "${CASKS[@]}"; do
       # Match the cask itself or any variant tap (e.g. ghostty@tip satisfies
@@ -192,7 +205,7 @@ install_deps() {
     done
 
     # macOS-only brew formulae
-    for formula in duti; do
+    for formula in duti sketchybar skhd yabai; do
       if command -v "$formula" &>/dev/null; then
         ok "$formula already installed"
       else
@@ -301,6 +314,21 @@ setup_tailnet_ssh() {
   fi
 }
 
+# --- macOS defaults ----------------------------------------------------------
+
+# Preferences that can't be stowed because they live in OS-managed plists.
+# Idempotent: re-running just re-asserts the values.
+setup_macos_defaults() {
+  [[ "$OS" == "Darwin" ]] || return
+
+  # Always show Sound in the menu bar so the sketchybar volume item can open its
+  # Control Center popover (see sketchybar/.config/sketchybar/plugins/cc_click.sh).
+  defaults write com.apple.controlcenter "NSStatusItem Visible Sound" -bool true
+  defaults write com.apple.controlcenter Sound -int 18
+  killall ControlCenter 2>/dev/null || true
+  ok "macOS defaults applied"
+}
+
 # --- Main --------------------------------------------------------------------
 
 main() {
@@ -316,6 +344,7 @@ main() {
   stow_packages
   setup_hooks
   setup_tailnet_ssh
+  setup_macos_defaults
 
   # Install everything declared in the stowed mise config (node, python, …).
   # Must run after stow_packages so the symlinked config is in place.

--- a/sketchybar/.config/sketchybar/colors.sh
+++ b/sketchybar/.config/sketchybar/colors.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Xcode Dark HC palette, taken from vim-colors-xcode/xcodedarkhc.
+# Shared by sketchybarrc and all plugins.
+export BAR_COLOR=0xff000000 # black background
+export BLACK=0xff1f1f24     # background, used as fg on bright fills
+export ITEM_BG=0xff34353b   # pill background (Xcode UI grey)
+export WHITE=0xffffffff     # HC foreground
+export GREY=0xff838991      # comment grey (secondary text)
+
+# Accent + syntax colors.
+export ACCENT=0xff6bdfff        # Xcode cyan
+export ACCENT_SUBTLE=0x336bdfff # cyan at ~20% alpha, for the active space tint
+export RED=0xffff8a7a
+export PINK=0xffff85b8
+export ORANGE=0xffffa14f
+export YELLOW=0xffd9c668
+export GREEN=0xffb8f08d
+export TEAL=0xff83c9bc
+export CYAN=0xff6bdfff
+export PURPLE=0xffcda1ff
+export BLUE=0xff4484d1
+
+# Active space tab fill (solid).
+export ACTIVE=0xffffa14f # Xcode orange

--- a/sketchybar/.config/sketchybar/icon_map.sh
+++ b/sketchybar/.config/sketchybar/icon_map.sh
@@ -1,0 +1,1676 @@
+#!/usr/bin/env bash
+
+### START-OF-ICON-MAP
+function __icon_map() {
+    case "$1" in
+   "Live")
+        icon_result=":ableton:"
+        ;;
+   "Acrobat")
+        icon_result=":acrobat:"
+        ;;
+   "Activity Monitor" | "Aktivitätsanzeige" | "Монітор активності" | "Монитор активности")
+        icon_result=":activity_monitor:"
+        ;;
+   "aw-tauri")
+        icon_result=":activitywatch:"
+        ;;
+   "Actual")
+        icon_result=":actual:"
+        ;;
+   "Adobe Bridge"*)
+        icon_result=":adobe_bridge:"
+        ;;
+   "AFFiNE")
+        icon_result=":affine:"
+        ;;
+   "Affinity")
+        icon_result=":affinity:"
+        ;;
+   "Affinity Designer")
+        icon_result=":affinity_designer:"
+        ;;
+   "Affinity Designer 2")
+        icon_result=":affinity_designer_2:"
+        ;;
+   "Affinity Photo")
+        icon_result=":affinity_photo:"
+        ;;
+   "Affinity Photo 2")
+        icon_result=":affinity_photo_2:"
+        ;;
+   "Affinity Publisher")
+        icon_result=":affinity_publisher:"
+        ;;
+   "Affinity Publisher 2")
+        icon_result=":affinity_publisher_2:"
+        ;;
+   "Airmail")
+        icon_result=":airmail:"
+        ;;
+   "AirPort Utility")
+        icon_result=":airport_utility:"
+        ;;
+   "AirVPN" | "Eddie")
+        icon_result=":airvpn:"
+        ;;
+   "Alacritty")
+        icon_result=":alacritty:"
+        ;;
+   "Alfred")
+        icon_result=":alfred:"
+        ;;
+   "AltTab")
+        icon_result=":alttab:"
+        ;;
+   "AmneziaVPN")
+        icon_result=":amnezia_vpn:"
+        ;;
+   "BlueStacks" | "HD-MultiInstanceManager")
+        icon_result=":android:"
+        ;;
+   "Android Messages")
+        icon_result=":android_messages:"
+        ;;
+   "Android Studio")
+        icon_result=":android_studio:"
+        ;;
+   "Anki")
+        icon_result=":anki:"
+        ;;
+   "Antigravity" | "Antigravity IDE")
+        icon_result=":antigravity:"
+        ;;
+   "AnyDesk")
+        icon_result=":anydesk:"
+        ;;
+   "Anytype")
+        icon_result=":anytype:"
+        ;;
+   "ApiArk")
+        icon_result=":apiark:"
+        ;;
+   "Apifox")
+        icon_result=":apifox:"
+        ;;
+   "App Eraser")
+        icon_result=":app_eraser:"
+        ;;
+   "App Store")
+        icon_result=":app_store:"
+        ;;
+   "Apple Books" | "Books" | "Bücher")
+        icon_result=":apple_books:"
+        ;;
+   "Apple Configurator")
+        icon_result=":apple_configurator:"
+        ;;
+   "TV")
+        icon_result=":apple_tv:"
+        ;;
+   "Arc")
+        icon_result=":arc:"
+        ;;
+   "Arduino" | "Arduino IDE")
+        icon_result=":arduino:"
+        ;;
+   "Aseprite")
+        icon_result=":aseprite:"
+        ;;
+   "Atom")
+        icon_result=":atom:"
+        ;;
+   "Audacity")
+        icon_result=":audacity:"
+        ;;
+   "Audio MIDI Setup")
+        icon_result=":audio_midi_setup:"
+        ;;
+   "Automator")
+        icon_result=":automator:"
+        ;;
+   "Azahar")
+        icon_result=":azahar:"
+        ;;
+   "Backblaze" | "Backblaze Downloader" | "Backblaze Restore")
+        icon_result=":backblaze:"
+        ;;
+   "BaiduNetdisk" | "百度网盘")
+        icon_result=":baidunetdisk:"
+        ;;
+   "balenaEtcher")
+        icon_result=":balena_etcher:"
+        ;;
+   "Bambu Studio")
+        icon_result=":bambu_studio:"
+        ;;
+   "MoneyMoney")
+        icon_result=":bank:"
+        ;;
+   "Basecamp" | "Basecamp.app")
+        icon_result=":basecamp:"
+        ;;
+   "Battle.net")
+        icon_result=":battle_net:"
+        ;;
+   "Bazaar")
+        icon_result=":bazaar:"
+        ;;
+   "Bazecor")
+        icon_result=":bazecor:"
+        ;;
+   "BBEdit")
+        icon_result=":bbedit:"
+        ;;
+   "Bear")
+        icon_result=":bear:"
+        ;;
+   "Beekeeper Studio")
+        icon_result=":beekeeper_studio:"
+        ;;
+   "Beeper" | "Beeper Desktop")
+        icon_result=":beeper:"
+        ;;
+   "BetterTouchTool")
+        icon_result=":bettertouchtool:"
+        ;;
+   "Bilibili" | "哔哩哔哩")
+        icon_result=":bilibili:"
+        ;;
+   "Bitwarden")
+        icon_result=":bit_warden:"
+        ;;
+   "Blender")
+        icon_result=":blender:"
+        ;;
+   "Blitzit")
+        icon_result=":blitzit:"
+        ;;
+   "Bluesky" | "Sky")
+        icon_result=":bluesky:"
+        ;;
+   "Bluetooth File Exchange" | "Bluetooth")
+        icon_result=":bluetooth:"
+        ;;
+   "BluOS Controller")
+        icon_result=":bluos_controller:"
+        ;;
+   "Calibre" | "Книги")
+        icon_result=":book:"
+        ;;
+   "YABA" | "Anybox" | "URL Manager Pro")
+        icon_result=":bookmark:"
+        ;;
+   "Brain.fm")
+        icon_result=":brainfm:"
+        ;;
+   "Brave Browser")
+        icon_result=":brave_browser:"
+        ;;
+   "Broadcasts")
+        icon_result=":broadcasts:"
+        ;;
+   "Bruno")
+        icon_result=":bruno:"
+        ;;
+   "Burn")
+        icon_result=":burn:"
+        ;;
+   "Burp Suite"*)
+        icon_result=":burp_suite:"
+        ;;
+   "BusyCal")
+        icon_result=":busycal:"
+        ;;
+   "Calculator" | "Calculette" | "Rechner" | "Калькулятор")
+        icon_result=":calculator:"
+        ;;
+   "Calendar" | "日历" | "Fantastical" | "Cron" | "Amie" | "Calendrier" | "カレンダー" | "Notion Calendar" | "Kalender" | "Календар" | "Календарь")
+        icon_result=":calendar:"
+        ;;
+   "calibre")
+        icon_result=":calibre:"
+        ;;
+   "Capacities")
+        icon_result=":capacities:"
+        ;;
+   "Caprine")
+        icon_result=":caprine:"
+        ;;
+   "ChatGPT Atlas")
+        icon_result=":chatgpt_atlas:"
+        ;;
+   "Cherry Studio")
+        icon_result=":cherry_studio:"
+        ;;
+   "Chess" | "The Enemy Within")
+        icon_result=":chess:"
+        ;;
+   "Amazon Chime")
+        icon_result=":chime:"
+        ;;
+   "Choosy")
+        icon_result=":choosy:"
+        ;;
+   "Cisco AnyConnect Secure Mobility Client" | "Cisco Secure Client")
+        icon_result=":cisco_anyconnect:"
+        ;;
+   "Citra")
+        icon_result=":citra:"
+        ;;
+   "Citrix Workspace" | "Citrix Viewer")
+        icon_result=":citrix:"
+        ;;
+   "ClassIn")
+        icon_result=":classin:"
+        ;;
+   "Claude")
+        icon_result=":claude:"
+        ;;
+   "ClickUp")
+        icon_result=":click_up:"
+        ;;
+   "CLion")
+        icon_result=":clion:"
+        ;;
+   "Clock")
+        icon_result=":clock:"
+        ;;
+   "cmux")
+        icon_result=":cmux:"
+        ;;
+   "coconutBattery")
+        icon_result=":coconut_battery:"
+        ;;
+   "Code" | "Code - Insiders" | "Electron")
+        icon_result=":code:"
+        ;;
+   "Codex")
+        icon_result=":codex:"
+        ;;
+   "Cold Turkey Blocker")
+        icon_result=":cold_turkey_blocker:"
+        ;;
+   "Color Picker" | "数码测色计" | "Кольоромір" | "Цифровой колориметр" | "Digital Color Meter")
+        icon_result=":color_picker:"
+        ;;
+   "Comet")
+        icon_result=":comet_browser:"
+        ;;
+   "Conductor")
+        icon_result=":conductor:"
+        ;;
+   "Console")
+        icon_result=":console:"
+        ;;
+   "Contacts")
+        icon_result=":contacts:"
+        ;;
+   "Copilot")
+        icon_result=":copilot:"
+        ;;
+   "CotEditor")
+        icon_result=":coteditor:"
+        ;;
+   "Craft")
+        icon_result=":craft:"
+        ;;
+   "Creative Cloud")
+        icon_result=":creative_cloud:"
+        ;;
+   "CrossOver")
+        icon_result=":crossover:"
+        ;;
+   "Cubase" | "Cubase Pro")
+        icon_result=":cubase:"
+        ;;
+   "CurseForge")
+        icon_result=":curseforge:"
+        ;;
+   "Cursor")
+        icon_result=":cursor:"
+        ;;
+   "Cypress")
+        icon_result=":cypress:"
+        ;;
+   "DaisyDisk")
+        icon_result=":daisy_disk:"
+        ;;
+   "Dash")
+        icon_result=":dash:"
+        ;;
+   "DataGrip")
+        icon_result=":datagrip:"
+        ;;
+   "DataSpell")
+        icon_result=":dataspell:"
+        ;;
+   "DaVinci Resolve")
+        icon_result=":davinciresolve:"
+        ;;
+   "DBeaver")
+        icon_result=":dbeaver:"
+        ;;
+   "DeepL")
+        icon_result=":deepl:"
+        ;;
+   "DeepSeek")
+        icon_result=":deepseek:"
+        ;;
+   "Deezer")
+        icon_result=":deezer:"
+        ;;
+   "Default")
+        icon_result=":default:"
+        ;;
+   "Default Folder X")
+        icon_result=":default_folder_x:"
+        ;;
+   "Deluge")
+        icon_result=":deluge:"
+        ;;
+   "deno")
+        icon_result=":deno:"
+        ;;
+   "CleanMyMac X")
+        icon_result=":desktop:"
+        ;;
+   "DEVONthink 3" | "DEVONthink")
+        icon_result=":devonthink3:"
+        ;;
+   "Dexcom")
+        icon_result=":dexcom:"
+        ;;
+   "Dia")
+        icon_result=":dia:"
+        ;;
+   "Dictionary")
+        icon_result=":dictionary:"
+        ;;
+   "DingTalk" | "钉钉" | "阿里钉")
+        icon_result=":dingtalk:"
+        ;;
+   "Discord" | "Discord Canary" | "Discord PTB")
+        icon_result=":discord:"
+        ;;
+   "Disk Utility")
+        icon_result=":disk_utility:"
+        ;;
+   "Docker" | "Docker Desktop")
+        icon_result=":docker:"
+        ;;
+   "GrandTotal" | "Receipts")
+        icon_result=":dollar:"
+        ;;
+   "Dolphin")
+        icon_result=":dolphin:"
+        ;;
+   "Dorico" | "Dorico Pro")
+        icon_result=":dorico:"
+        ;;
+   "Dota2")
+        icon_result=":dota2:"
+        ;;
+   "Double Commander")
+        icon_result=":doublecmd:"
+        ;;
+   "Downie 4")
+        icon_result=":downie:"
+        ;;
+   "Drafts")
+        icon_result=":drafts:"
+        ;;
+   "draw.io")
+        icon_result=":draw_io:"
+        ;;
+   "Dropbox")
+        icon_result=":dropbox:"
+        ;;
+   "Dropover")
+        icon_result=":dropover:"
+        ;;
+   "DSM")
+        icon_result=":dsm:"
+        ;;
+   "DVD Player")
+        icon_result=":dvd_player:"
+        ;;
+   "EA app")
+        icon_result=":ea:"
+        ;;
+   "Eagle")
+        icon_result=":eagle:"
+        ;;
+   "Element")
+        icon_result=":element:"
+        ;;
+   "Emacs")
+        icon_result=":emacs:"
+        ;;
+   "Epic Games Launcher")
+        icon_result=":epic_games:"
+        ;;
+   "EuDic")
+        icon_result=":eudic:"
+        ;;
+   "Evernote Legacy" | "Evernote")
+        icon_result=":evernote_legacy:"
+        ;;
+   "FaceTime" | "FaceTime 通话")
+        icon_result=":face_time:"
+        ;;
+   "Feedback Assistant")
+        icon_result=":feedback_assistant:"
+        ;;
+   "Feishu" | "飞书" | "飞书会议")
+        icon_result=":feishu:"
+        ;;
+   "Figma")
+        icon_result=":figma:"
+        ;;
+   "FileBot")
+        icon_result=":filebot:"
+        ;;
+   "FileZilla")
+        icon_result=":filezilla:"
+        ;;
+   "Final Cut Pro")
+        icon_result=":final_cut_pro:"
+        ;;
+   "Finamp")
+        icon_result=":finamp:"
+        ;;
+   "Find My" | "Локатор")
+        icon_result=":find_my:"
+        ;;
+   "Finder" | "访达" | "Bloom" | "FlowFinder")
+        icon_result=":finder:"
+        ;;
+   "Firefox")
+        icon_result=":firefox:"
+        ;;
+   "Firefox Developer Edition" | "Firefox Nightly")
+        icon_result=":firefox_developer_edition:"
+        ;;
+   "Flaresolverr")
+        icon_result=":flaresolverr:"
+        ;;
+   "Floorp")
+        icon_result=":floorp:"
+        ;;
+   "FL Studio")
+        icon_result=":flstudio:"
+        ;;
+   "Fluxer")
+        icon_result=":fluxer:"
+        ;;
+   "FMOD Studio")
+        icon_result=":fmod:"
+        ;;
+   "Folx")
+        icon_result=":folx:"
+        ;;
+   "Font Book")
+        icon_result=":font_book:"
+        ;;
+   "foobar2000")
+        icon_result=":foobar2000:"
+        ;;
+   "Fork")
+        icon_result=":fork:"
+        ;;
+   "ForkLift")
+        icon_result=":forklift:"
+        ;;
+   "Foxit PDF Reader")
+        icon_result=":foxit_reader:"
+        ;;
+   "FreeCAD")
+        icon_result=":freecad:"
+        ;;
+   "Freeform")
+        icon_result=":freeform:"
+        ;;
+   "FreeTube")
+        icon_result=":freetube:"
+        ;;
+   "FSNotes")
+        icon_result=":fsnotes:"
+        ;;
+   "Fusion")
+        icon_result=":fusion:"
+        ;;
+   "Games")
+        icon_result=":games:"
+        ;;
+   "System Preferences" | "System Settings" | "系统设置" | "Réglages Système" | "システム設定" | "Systemeinstellungen" | "System­einstellungen" | "Системні параметри" | "Системные настройки")
+        icon_result=":gear:"
+        ;;
+   "Gemini" | "Google Gemini")
+        icon_result=":gemini:"
+        ;;
+   "Ghostty")
+        icon_result=":ghostty:"
+        ;;
+   "GIMP")
+        icon_result=":gimp:"
+        ;;
+   "GitHub Desktop")
+        icon_result=":git_hub:"
+        ;;
+   "GitKraken")
+        icon_result=":gitkraken:"
+        ;;
+   "Godot")
+        icon_result=":godot:"
+        ;;
+   "GOG Galaxy")
+        icon_result=":gog_galaxy:"
+        ;;
+   "GoLand")
+        icon_result=":goland:"
+        ;;
+   "GoodLinks")
+        icon_result=":goodlinks:"
+        ;;
+   "Goodnotes")
+        icon_result=":goodnotes:"
+        ;;
+   "Google Chat")
+        icon_result=":google_chat:"
+        ;;
+   "Chromium" | "Google Chrome" | "Google Chrome Canary")
+        icon_result=":google_chrome:"
+        ;;
+   "Google Drive")
+        icon_result=":google_drive:"
+        ;;
+   "Grammarly Editor")
+        icon_result=":grammarly:"
+        ;;
+   "Granola")
+        icon_result=":granola:"
+        ;;
+   "Grapher")
+        icon_result=":grapher:"
+        ;;
+   "Grayjay")
+        icon_result=":grayjay:"
+        ;;
+   "Hammerspoon")
+        icon_result=":hammerspoon:"
+        ;;
+   "HandBrake")
+        icon_result=":handbrake:"
+        ;;
+   "Hazel")
+        icon_result=":hazel:"
+        ;;
+   "HBO Max")
+        icon_result=":hbo_max:"
+        ;;
+   "Helium")
+        icon_result=":helium:"
+        ;;
+   "Hex Fiend")
+        icon_result=":hex_fiend:"
+        ;;
+   "Home")
+        icon_result=":home:"
+        ;;
+   "Home Assistant")
+        icon_result=":home_assistant:"
+        ;;
+   "Hyper")
+        icon_result=":hyper:"
+        ;;
+   "Hyperkey")
+        icon_result=":hyperkey:"
+        ;;
+   "iA Writer")
+        icon_result=":ia_writer:"
+        ;;
+   "Ice Cubes")
+        icon_result=":ice_cubes:"
+        ;;
+   "IntelliJ IDEA")
+        icon_result=":idea:"
+        ;;
+   "IINA")
+        icon_result=":iina:"
+        ;;
+   "Adobe Illustrator"* | "Illustrator")
+        icon_result=":illustrator:"
+        ;;
+   "Image Playground")
+        icon_result=":image_playground:"
+        ;;
+   "ImHex")
+        icon_result=":imhex:"
+        ;;
+   "Adobe InDesign"* | "InDesign")
+        icon_result=":indesign:"
+        ;;
+   "Infuse")
+        icon_result=":infuse:"
+        ;;
+   "Inkdrop")
+        icon_result=":inkdrop:"
+        ;;
+   "Inkscape")
+        icon_result=":inkscape:"
+        ;;
+   "Insomnia")
+        icon_result=":insomnia:"
+        ;;
+   "Instagram")
+        icon_result=":instagram:"
+        ;;
+   "Instapaper")
+        icon_result=":instapaper:"
+        ;;
+   "iPhone Mirroring")
+        icon_result=":iphone_mirroring:"
+        ;;
+   "Iris")
+        icon_result=":iris:"
+        ;;
+   "iTerm" | "iTerm2")
+        icon_result=":iterm:"
+        ;;
+   "Product Portal" | "iZotope RX 9" | "iZotope RX 10" | "iZotope RX 11" | "iZotope RX 12" | "iZotope Ozone 9" | "iZotope Ozone 10" | "iZotope Ozone 11" | "iZotope Ozone 12")
+        icon_result=":izotope:"
+        ;;
+   "Jane Reader")
+        icon_result=":jane_reader:"
+        ;;
+   "JDownloader" | "JDownloader2" | "Uninstall JDownloader")
+        icon_result=":jdownloader:"
+        ;;
+   "Jellyfin Media Player")
+        icon_result=":jellyfin:"
+        ;;
+   "Jellyseer")
+        icon_result=":jellyseer:"
+        ;;
+   "JetBrains Gateway")
+        icon_result=":jetbrains_gateway:"
+        ;;
+   "JetBrains Toolbox")
+        icon_result=":jetbrains_toolbox:"
+        ;;
+   "Joplin")
+        icon_result=":joplin:"
+        ;;
+   "Journal")
+        icon_result=":journal:"
+        ;;
+   "JuxtaText")
+        icon_result=":juxtatext:"
+        ;;
+   "카카오톡" | "KakaoTalk")
+        icon_result=":kakaotalk:"
+        ;;
+   "Kakoune")
+        icon_result=":kakoune:"
+        ;;
+   "Karabiner-Elements Settings" | "Karabiner-Elements")
+        icon_result=":karabiner_elements:"
+        ;;
+   "Karabiner-EventViewer")
+        icon_result=":karabiner_elements_event_viewer:"
+        ;;
+   "KeePassXC")
+        icon_result=":kee_pass_x_c:"
+        ;;
+   "Keyboard Maestro")
+        icon_result=":keyboard_maestro:"
+        ;;
+   "Keychain Access")
+        icon_result=":keychain_access:"
+        ;;
+   "Keynote" | "Keynote 讲演")
+        icon_result=":keynote:"
+        ;;
+   "KiCad")
+        icon_result=":kicad:"
+        ;;
+   "Kiro")
+        icon_result=":kiro:"
+        ;;
+   "kitty")
+        icon_result=":kitty:"
+        ;;
+   "Kodi")
+        icon_result=":kodi:"
+        ;;
+   "krita")
+        icon_result=":krita:"
+        ;;
+   "LanguageTool for Desktop")
+        icon_result=":languagetool_for_desktop:"
+        ;;
+   "League of Legends")
+        icon_result=":league_of_legends:"
+        ;;
+   "legcord" | "Legcord")
+        icon_result=":legcord:"
+        ;;
+   "LibreWolf")
+        icon_result=":libre_wolf:"
+        ;;
+   "LibreOffice")
+        icon_result=":libreoffice:"
+        ;;
+   "Lidarr")
+        icon_result=":lidarr:"
+        ;;
+   "Adobe Lightroom")
+        icon_result=":lightroom:"
+        ;;
+   "Lightroom Classic")
+        icon_result=":lightroomclassic:"
+        ;;
+   "LINE")
+        icon_result=":line:"
+        ;;
+   "Linear")
+        icon_result=":linear:"
+        ;;
+   "Little Snitch" | "Little Snitch Network Monitor")
+        icon_result=":little_snitch:"
+        ;;
+   "Little Snitch Mini"*)
+        icon_result=":little_snitch_mini:"
+        ;;
+   "LM Studio")
+        icon_result=":lm_studio:"
+        ;;
+   "LobeHub")
+        icon_result=":lobehub:"
+        ;;
+   "LocalSend")
+        icon_result=":localsend:"
+        ;;
+   "Logic Pro")
+        icon_result=":logicpro:"
+        ;;
+   "Logseq")
+        icon_result=":logseq:"
+        ;;
+   "LuLu")
+        icon_result=":lulu:"
+        ;;
+   "Maccy")
+        icon_result=":maccy_clip:"
+        ;;
+   "MacForge")
+        icon_result=":macforge:"
+        ;;
+   "MacPass")
+        icon_result=":macpass:"
+        ;;
+   "Mactracker")
+        icon_result=":mactracker:"
+        ;;
+   "Magnifier")
+        icon_result=":magnifier:"
+        ;;
+   "Canary Mail" | "HEY" | "Mail" | "Mailspring" | "MailMate" | "Superhuman" | "Spark" | "Spark Mail" | "邮件" | "メール" | "Пошта" | "Почта")
+        icon_result=":mail:"
+        ;;
+   "MakeMKV")
+        icon_result=":makemkv:"
+        ;;
+   "MAMP" | "MAMP PRO")
+        icon_result=":mamp:"
+        ;;
+   "Maps" | "Google Maps" | "マップ" | "Karten" | "Карти" | "Карты")
+        icon_result=":maps:"
+        ;;
+   "Marked 2")
+        icon_result=":marked_2:"
+        ;;
+   "Marta")
+        icon_result=":marta:"
+        ;;
+   "Matlab" | "MATLAB" |"MATLABWindow" | "MATLAB_R2024b" | "MATLAB_R2024a" | "MATLAB_R2023b" | "MATLAB_R2023a" | "MATLAB_R2022b" | "MATLAB_R2022a" | "MATLAB_R2021b" | "MATLAB_R2021a")
+        icon_result=":matlab:"
+        ;;
+   "Mattermost")
+        icon_result=":mattermost:"
+        ;;
+   "MediaInfo")
+        icon_result=":mediainfo:"
+        ;;
+   "Google Meet")
+        icon_result=":meet:"
+        ;;
+   "MEGA")
+        icon_result=":mega:"
+        ;;
+   "Messages" | "信息" | "Nachrichten" | "メッセージ" | "Повідомлення" | "Сообщения")
+        icon_result=":messages:"
+        ;;
+   "Messenger")
+        icon_result=":messenger:"
+        ;;
+   "Microsoft Edge")
+        icon_result=":microsoft_edge:"
+        ;;
+   "Microsoft Excel")
+        icon_result=":microsoft_excel:"
+        ;;
+   "Microsoft Outlook")
+        icon_result=":microsoft_outlook:"
+        ;;
+   "Microsoft PowerPoint")
+        icon_result=":microsoft_power_point:"
+        ;;
+   "Microsoft Remote Desktop")
+        icon_result=":microsoft_remote_desktop:"
+        ;;
+   "Microsoft Teams" | "Microsoft Teams (work or school)")
+        icon_result=":microsoft_teams:"
+        ;;
+   "Microsoft Word")
+        icon_result=":microsoft_word:"
+        ;;
+   "Migaku")
+        icon_result=":migaku:"
+        ;;
+   "Mimestream")
+        icon_result=":mimestream:"
+        ;;
+   "Min")
+        icon_result=":min_browser:"
+        ;;
+   "Minecraft" | "Minecraft Launcher")
+        icon_result=":minecraft:"
+        ;;
+   "Miro")
+        icon_result=":miro:"
+        ;;
+   "MongoDB Compass"*)
+        icon_result=":mongodb:"
+        ;;
+   "Moonlight")
+        icon_result=":moonlight:"
+        ;;
+   "Motrix")
+        icon_result=":motrix:"
+        ;;
+   "Movist Pro")
+        icon_result=":movist_pro:"
+        ;;
+   "Mp3tag")
+        icon_result=":mp3tag:"
+        ;;
+   "mpv")
+        icon_result=":mpv:"
+        ;;
+   "MQTTX")
+        icon_result=":mqttx:"
+        ;;
+   "MTGA")
+        icon_result=":mtga:"
+        ;;
+   "Mullvad Browser")
+        icon_result=":mullvad_browser:"
+        ;;
+   "Mullvad VPN")
+        icon_result=":mullvad_vpn:"
+        ;;
+   "MuseHub")
+        icon_result=":musehub:"
+        ;;
+   "MuseScore" | "MuseScore 4" | "MuseScore Studio")
+        icon_result=":musescore:"
+        ;;
+   "Music" | "音乐" | "Musique" | "ミュージック" | "Musik" | "Chromatix" | "Музика" | "Музыка")
+        icon_result=":music:"
+        ;;
+   "Native Access")
+        icon_result=":native_instruments:"
+        ;;
+   "Navicat Premium")
+        icon_result=":navicat:"
+        ;;
+   "Neovide" | "neovide")
+        icon_result=":neovide:"
+        ;;
+   "Neovim" | "neovim" | "nvim")
+        icon_result=":neovim:"
+        ;;
+   "网易云音乐" | "NetEaseMusic")
+        icon_result=":netease_music:"
+        ;;
+   "Netflix")
+        icon_result=":netflix:"
+        ;;
+   "NetNewsWire")
+        icon_result=":netnewswire:"
+        ;;
+   "MA 1 - Automatic Monitor Alignment")
+        icon_result=":neumann:"
+        ;;
+   "News")
+        icon_result=":news:"
+        ;;
+   "Nextcloud")
+        icon_result=":nextcloud:"
+        ;;
+   "Nicotine+")
+        icon_result=":nicotine_plus:"
+        ;;
+   "Nimble Commander" | "NimbleCommander-Unsigned")
+        icon_result=":nimble_commander:"
+        ;;
+   "Noodl" | "Noodl Editor")
+        icon_result=":noodl:"
+        ;;
+   "NordVPN")
+        icon_result=":nord_vpn:"
+        ;;
+   "Notability")
+        icon_result=":notability:"
+        ;;
+   "Notes" | "备忘录" | "メモ" | "Notizen" | "Нотатки" | "Заметки")
+        icon_result=":notes:"
+        ;;
+   "Notion")
+        icon_result=":notion:"
+        ;;
+   "Notion Mail")
+        icon_result=":notion_mail:"
+        ;;
+   "Nova")
+        icon_result=":nova:"
+        ;;
+   "Numbers" | "Numbers 表格")
+        icon_result=":numbers:"
+        ;;
+   "nvALT")
+        icon_result=":nvalt:"
+        ;;
+   "Nvidia GeForce Now" | "GeForceNOW")
+        icon_result=":nvidia_geforce_now:"
+        ;;
+   "Nzbget")
+        icon_result=":nzbget:"
+        ;;
+   "Obsidian")
+        icon_result=":obsidian:"
+        ;;
+   "OBS")
+        icon_result=":obsstudio:"
+        ;;
+   "Ollama")
+        icon_result=":ollama:"
+        ;;
+   "OmniDiskSweeper")
+        icon_result=":omni_disk_sweeper:"
+        ;;
+   "OmniFocus")
+        icon_result=":omni_focus:"
+        ;;
+   "1Password")
+        icon_result=":one_password:"
+        ;;
+   "OneDrive")
+        icon_result=":onedrive:"
+        ;;
+   "Open Video Downloader")
+        icon_result=":open_video_downloader:"
+        ;;
+   "ChatGPT")
+        icon_result=":openai:"
+        ;;
+   "OpenAI Translator")
+        icon_result=":openai_translator:"
+        ;;
+   "opencode")
+        icon_result=":opencode:"
+        ;;
+   "OpenEmu")
+        icon_result=":openemu:"
+        ;;
+   "OpenVPN Connect")
+        icon_result=":openvpn_connect:"
+        ;;
+   "Opera")
+        icon_result=":opera:"
+        ;;
+   "OrbStack")
+        icon_result=":orbstack:"
+        ;;
+   "OrcaSlicer")
+        icon_result=":orcaslicer:"
+        ;;
+   "Orion" | "Orion RC")
+        icon_result=":orion:"
+        ;;
+   "Overcast")
+        icon_result=":overcast:"
+        ;;
+   "Overleaf" | "ShareLaTeX")
+        icon_result=":overleaf:"
+        ;;
+   "Overseer" | "Seer")
+        icon_result=":overseer:"
+        ;;
+   "Pages" | "Pages 文稿")
+        icon_result=":pages:"
+        ;;
+   "Parallels Desktop")
+        icon_result=":parallels:"
+        ;;
+   "Parcel")
+        icon_result=":parcel:"
+        ;;
+   "Parsec")
+        icon_result=":parsec:"
+        ;;
+   "Passepartout")
+        icon_result=":passepartout:"
+        ;;
+   "Password Depot")
+        icon_result=":password_depot:"
+        ;;
+   "AutoFillPanelService" | "coreautha" | "Passwords" | "Passwörter" | "Паролі" | "Пароли")
+        icon_result=":passwords:"
+        ;;
+   "PasteBar")
+        icon_result=":pastebar:"
+        ;;
+   "PCSX2")
+        icon_result=":pcsx2:"
+        ;;
+   "PDF Expert")
+        icon_result=":pdf_expert:"
+        ;;
+   "Pearcleaner")
+        icon_result=":pearcleaner:"
+        ;;
+   "Perplexity" | "Perplexity AI")
+        icon_result=":perplexity:"
+        ;;
+   "pgAdmin 4")
+        icon_result=":pgadmin:"
+        ;;
+   "Phoenix Slides")
+        icon_result=":phoenix_slides:"
+        ;;
+   "Phone")
+        icon_result=":phone:"
+        ;;
+   "Photos" | "Fotos" | "Фото")
+        icon_result=":photos:"
+        ;;
+   "Adobe Photoshop"*)
+        icon_result=":photoshop:"
+        ;;
+   "PhpStorm")
+        icon_result=":php_storm:"
+        ;;
+   "Pi-hole Remote")
+        icon_result=":pihole:"
+        ;;
+   "Pine")
+        icon_result=":pine:"
+        ;;
+   "Pinta")
+        icon_result=":pinta:"
+        ;;
+   "Pixcall")
+        icon_result=":pixcall:"
+        ;;
+   "Pixelmator Pro")
+        icon_result=":pixelmator_pro:"
+        ;;
+   "Play")
+        icon_result=":play:"
+        ;;
+   "Plex")
+        icon_result=":plex:"
+        ;;
+   "Plexamp")
+        icon_result=":plexamp:"
+        ;;
+   "Plezy")
+        icon_result=":plezy:"
+        ;;
+   "Podcasts" | "播客" | "Подкасти" | "Подкасты")
+        icon_result=":podcasts:"
+        ;;
+   "PomoDone App")
+        icon_result=":pomodone:"
+        ;;
+   "Postman")
+        icon_result=":postman:"
+        ;;
+   "Premiere" | "Adobe Premiere" | "Adobe Premiere Pro 2024")
+        icon_result=":premiere:"
+        ;;
+   "Preview" | "预览" | "Skim" | "zathura" | "Aperçu" | "プレビュー" | "Vorschau" | "Оглядач" | "Просмотр")
+        icon_result=":preview:"
+        ;;
+   "Print Center" | "Druckzentrale")
+        icon_result=":print_center:"
+        ;;
+   "Pro Tools")
+        icon_result=":pro_tools:"
+        ;;
+   "Problem Reporter")
+        icon_result=":problem_reporter:"
+        ;;
+   "Proton Mail" | "Proton Mail Bridge")
+        icon_result=":proton_mail:"
+        ;;
+   "Proton VPN" | "ProtonVPN")
+        icon_result=":proton_vpn:"
+        ;;
+   "Prowlarr")
+        icon_result=":prowlarr:"
+        ;;
+   "Proxyman")
+        icon_result=":proxyman:"
+        ;;
+   "PrusaSlicer" | "SuperSlicer")
+        icon_result=":prusaslicer:"
+        ;;
+   "PS Remote Play")
+        icon_result=":ps_remote_play:"
+        ;;
+   "PyCharm")
+        icon_result=":pycharm:"
+        ;;
+   "qBittorrent")
+        icon_result=":qbittorrent:"
+        ;;
+   "QBZ")
+        icon_result=":qbz:"
+        ;;
+   "QGIS")
+        icon_result=":qgis:"
+        ;;
+   "QLMarkdown")
+        icon_result=":qlmarkdown:"
+        ;;
+   "Qobuz")
+        icon_result=":qobuz:"
+        ;;
+   "QQ")
+        icon_result=":qq:"
+        ;;
+   "QQ音乐" | "QQMusic")
+        icon_result=":qqmusic:"
+        ;;
+   "Quantumult X")
+        icon_result=":quantumult_x:"
+        ;;
+   "Quark" | "夸克")
+        icon_result=":quark:"
+        ;;
+   "QuickTime Player")
+        icon_result=":quicktime:"
+        ;;
+   "Quip")
+        icon_result=":quip:"
+        ;;
+   "qutebrowser")
+        icon_result=":qute_browser:"
+        ;;
+   "Radarr")
+        icon_result=":radarr:"
+        ;;
+   "Raindrop.io")
+        icon_result=":raindrop_io:"
+        ;;
+   "Raspberry Pi Imager" | "Raspberry Pi Connect")
+        icon_result=":raspberry_pi:"
+        ;;
+   "Raycast" | "Raycast Beta")
+        icon_result=":raycast:"
+        ;;
+   "Reeder")
+        icon_result=":reeder5:"
+        ;;
+   "rekordbox")
+        icon_result=":rekordbox:"
+        ;;
+   "Remind Faster")
+        icon_result=":remind_me_faster:"
+        ;;
+   "Reminders" | "提醒事项" | "Rappels" | "リマインダー" | "Erinnerungen" | "Нагадування" | "Напоминания")
+        icon_result=":reminders:"
+        ;;
+   "RenameMyTVSeries" | "Rename My TV Series")
+        icon_result=":rename_my_tv_series:"
+        ;;
+   "Replit")
+        icon_result=":replit:"
+        ;;
+   "Repo Prompt")
+        icon_result=":repo_prompt:"
+        ;;
+   "Resilio Sync")
+        icon_result=":resilio_sync:"
+        ;;
+   "Rider" | "JetBrains Rider")
+        icon_result=":rider:"
+        ;;
+   "Rio")
+        icon_result=":rio:"
+        ;;
+   "Roblox")
+        icon_result=":roblox:"
+        ;;
+   "Royal TSX")
+        icon_result=":royaltsx:"
+        ;;
+   "RStudio")
+        icon_result=":rstudio:"
+        ;;
+   "ruffle")
+        icon_result=":ruffle:"
+        ;;
+   "RustDesk")
+        icon_result=":rustdesk:"
+        ;;
+   "SABnzbd")
+        icon_result=":sabnzbd:"
+        ;;
+   "Safari" | "Safari浏览器" | "Safari Technology Preview")
+        icon_result=":safari:"
+        ;;
+   "Screencap")
+        icon_result=":screencap:"
+        ;;
+   "Scribus")
+        icon_result=":scribus:"
+        ;;
+   "Script Debugger")
+        icon_result=":script_debugger:"
+        ;;
+   "Script Editor")
+        icon_result=":script_editor:"
+        ;;
+   "Seafile")
+        icon_result=":seafile:"
+        ;;
+   "Sequel Ace")
+        icon_result=":sequel_ace:"
+        ;;
+   "Sequel Pro")
+        icon_result=":sequel_pro:"
+        ;;
+   "Session")
+        icon_result=":session:"
+        ;;
+   "Setapp")
+        icon_result=":setapp:"
+        ;;
+   "SF Symbols" | "SF Symbole" | "SF-Symbole")
+        icon_result=":sf_symbols:"
+        ;;
+   "Shapr3D")
+        icon_result=":shapr3d:"
+        ;;
+   "Shortcuts" | "Команди" | "Команды")
+        icon_result=":shortcuts:"
+        ;;
+   "Sibelius")
+        icon_result=":sibelius:"
+        ;;
+   "Signal")
+        icon_result=":signal:"
+        ;;
+   "sioyek")
+        icon_result=":sioyek:"
+        ;;
+   "Sketch")
+        icon_result=":sketch:"
+        ;;
+   "Skype")
+        icon_result=":skype:"
+        ;;
+   "Slack")
+        icon_result=":slack:"
+        ;;
+   "SmartGit")
+        icon_result=":smartgit:"
+        ;;
+   "SnippetsLab")
+        icon_result=":snippetslab:"
+        ;;
+   "solidtime")
+        icon_result=":solidtime:"
+        ;;
+   "Sonarr")
+        icon_result=":sonarr:"
+        ;;
+   "Sourcetree")
+        icon_result=":sourcetree:"
+        ;;
+   "Spark Desktop")
+        icon_result=":spark:"
+        ;;
+   "Sparkle")
+        icon_result=":sparkle:"
+        ;;
+   "Spotify")
+        icon_result=":spotify:"
+        ;;
+   "Spotlight")
+        icon_result=":spotlight:"
+        ;;
+   "StarUML")
+        icon_result=":staruml:"
+        ;;
+   "Steam" | "Steam Helper")
+        icon_result=":steam:"
+        ;;
+   "Stickies")
+        icon_result=":stickies:"
+        ;;
+   "Stocks")
+        icon_result=":stocks:"
+        ;;
+   "Stremio")
+        icon_result=":stremio:"
+        ;;
+   "Studio 3T")
+        icon_result=":studio_3t:"
+        ;;
+   "Sublime Merge")
+        icon_result=":sublime_merge:"
+        ;;
+   "Sublime Text")
+        icon_result=":sublime_text:"
+        ;;
+   "Summoners War")
+        icon_result=":summoners_war:"
+        ;;
+   "superProductivity")
+        icon_result=":superproductivity:"
+        ;;
+   "Surfshark")
+        icon_result=":surfshark:"
+        ;;
+   "Swift Playground")
+        icon_result=":swift_playground:"
+        ;;
+   "Synergy")
+        icon_result=":synergy:"
+        ;;
+   "System Information" | "System Profiler")
+        icon_result=":system_information:"
+        ;;
+   "T3 Chat")
+        icon_result=":t3chat:"
+        ;;
+   "Tabby")
+        icon_result=":tabby:"
+        ;;
+   "TablePlus")
+        icon_result=":tableplus:"
+        ;;
+   "Tailscale")
+        icon_result=":tailscale:"
+        ;;
+   "Tana")
+        icon_result=":tana:"
+        ;;
+   "Tautulli")
+        icon_result=":tautulli:"
+        ;;
+   "TeamSpeak 3")
+        icon_result=":team_speak:"
+        ;;
+   "TeamViewer")
+        icon_result=":teamviewer:"
+        ;;
+   "Telegram")
+        icon_result=":telegram:"
+        ;;
+   "Terminal" | "终端" | "ターミナル" | "Термінал" | "Терминал")
+        icon_result=":terminal:"
+        ;;
+   "Termius")
+        icon_result=":termius:"
+        ;;
+   "TestFlight")
+        icon_result=":testflight:"
+        ;;
+   "Typora")
+        icon_result=":text:"
+        ;;
+   "TextEdit")
+        icon_result=":textedit:"
+        ;;
+   "The Sims 3" | "The Sims 4")
+        icon_result=":the_sims:"
+        ;;
+   "Microsoft To Do" | "Things")
+        icon_result=":things:"
+        ;;
+   "Thunderbird" | "Thunderbird Daily")
+        icon_result=":thunderbird:"
+        ;;
+   "TickTick")
+        icon_result=":tick_tick:"
+        ;;
+   "TIDAL")
+        icon_result=":tidal:"
+        ;;
+   "TigerVNC")
+        icon_result=":tigervnc:"
+        ;;
+   "Time Machine" | "TimeMachineEditor" | "TheTimeMachineMechanic")
+        icon_result=":time_machine:"
+        ;;
+   "Timery")
+        icon_result=":timery:"
+        ;;
+   "Timing")
+        icon_result=":timingapp:"
+        ;;
+   "Tiny RDM")
+        icon_result=":tinyrdm:"
+        ;;
+   "Tips")
+        icon_result=":tips:"
+        ;;
+   "Todoist")
+        icon_result=":todoist:"
+        ;;
+   "Toggl Track")
+        icon_result=":toggl_track:"
+        ;;
+   "Tor Browser")
+        icon_result=":tor_browser:"
+        ;;
+   "Tot")
+        icon_result=":tot:"
+        ;;
+   "Tower")
+        icon_result=":tower:"
+        ;;
+   "TradingView")
+        icon_result=":trading_view:"
+        ;;
+   "Transmission")
+        icon_result=":transmission:"
+        ;;
+   "Transmit")
+        icon_result=":transmit:"
+        ;;
+   "Trello")
+        icon_result=":trello:"
+        ;;
+   "Twingate")
+        icon_result=":twingate:"
+        ;;
+   "Tweetbot" | "Twitter")
+        icon_result=":twitter:"
+        ;;
+   "UGREEN NAS")
+        icon_result=":ugreen-nas:"
+        ;;
+   "Unity" | "Unity Hub")
+        icon_result=":unity:"
+        ;;
+   "Usenapp")
+        icon_result=":usenapp:"
+        ;;
+   "UTM")
+        icon_result=":utm:"
+        ;;
+   "VeraCrypt")
+        icon_result=":veracrypt:"
+        ;;
+   "Vesktop")
+        icon_result=":vesktop:"
+        ;;
+   "Viber")
+        icon_result=":viber:"
+        ;;
+   "MacVim" | "Vim" | "VimR")
+        icon_result=":vim:"
+        ;;
+   "VirtualBox")
+        icon_result=":virtualbox:"
+        ;;
+   "Visual Studio")
+        icon_result=":visual_studio:"
+        ;;
+   "Vivaldi")
+        icon_result=":vivaldi:"
+        ;;
+   "VLC")
+        icon_result=":vlc:"
+        ;;
+   "VMware Fusion")
+        icon_result=":vmware_fusion:"
+        ;;
+   "Voice Memos")
+        icon_result=":voice_memos:"
+        ;;
+   "Vorta")
+        icon_result=":vorta:"
+        ;;
+   "VSCodium")
+        icon_result=":vscodium:"
+        ;;
+   "Warp")
+        icon_result=":warp:"
+        ;;
+   "Wave")
+        icon_result=":waveterm:"
+        ;;
+   "Weather" | "Wetter" | "Погода")
+        icon_result=":weather:"
+        ;;
+   "WebStorm")
+        icon_result=":web_storm:"
+        ;;
+   "WebTorrent")
+        icon_result=":webtorrent:"
+        ;;
+   "Webull Desktop")
+        icon_result=":webull:"
+        ;;
+   "微信" | "WeChat")
+        icon_result=":wechat:"
+        ;;
+   "企业微信" | "WeCom")
+        icon_result=":wecom:"
+        ;;
+   "WezTerm" | "wezterm-gui")
+        icon_result=":wezterm:"
+        ;;
+   "WhatsApp" | "‎WhatsApp")
+        icon_result=":whats_app:"
+        ;;
+   "Windows App")
+        icon_result=":windows_app:"
+        ;;
+   "WireGuard")
+        icon_result=":wireguard:"
+        ;;
+   "Wireshark")
+        icon_result=":wireshark:"
+        ;;
+   "Wispr Flow")
+        icon_result=":wispr_flow:"
+        ;;
+   "xemu")
+        icon_result=":xbox:"
+        ;;
+   "Xcode")
+        icon_result=":xcode:"
+        ;;
+   "XMind")
+        icon_result=":xmind:"
+        ;;
+   "Yaak")
+        icon_result=":yaak:"
+        ;;
+   "Yandex Browser"  | "Yandex Browser" | "Yandex")
+        icon_result=":yandex_browser:"
+        ;;
+   "Yandex Music")
+        icon_result=":yandex_music:"
+        ;;
+   "Yazi" | "yazi")
+        icon_result=":yazi:"
+        ;;
+   "YouTube")
+        icon_result=":youtube:"
+        ;;
+   "YouTube Music")
+        icon_result=":youtube_music:"
+        ;;
+   "Yubico Authenticator" | "YubiKey Manager")
+        icon_result=":yubico:"
+        ;;
+   "Yuque" | "语雀")
+        icon_result=":yuque:"
+        ;;
+   "Z-Library")
+        icon_result=":z_library:"
+        ;;
+   "Zed")
+        icon_result=":zed:"
+        ;;
+   "Zen" | "Zen Browser" | "Twilight")
+        icon_result=":zen_browser:"
+        ;;
+   "Zeplin")
+        icon_result=":zeplin:"
+        ;;
+   "zoom.us")
+        icon_result=":zoom:"
+        ;;
+   "Zotero")
+        icon_result=":zotero:"
+        ;;
+   "Zulip")
+        icon_result=":zulip:"
+        ;;
+    *)
+        icon_result=":default:"
+        ;;
+    esac
+}
+### END-OF-ICON-MAP
+
+# When executed directly (not sourced), map all arguments and print space-separated results.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    for app_name in "$@"; do
+        __icon_map "$app_name"
+        printf '%s ' "$icon_result"
+    done
+    [[ $# -gt 0 ]] && printf '\n'
+fi

--- a/sketchybar/.config/sketchybar/icons.sh
+++ b/sketchybar/.config/sketchybar/icons.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Nerd Font (Iosevka Nerd Font) glyphs, written as literal UTF-8 so no
+# runtime decoding is needed. Codepoints are Font Awesome (nf-fa-*).
+export ICON_CLOCK=""
+export ICON_BATT_FULL=""
+export ICON_BATT_75=""
+export ICON_BATT_50=""
+export ICON_BATT_25=""
+export ICON_BATT_EMPTY=""
+export ICON_BATT_CHARGING=""
+export ICON_VOL_HIGH=""
+export ICON_VOL_MID=""
+export ICON_VOL_LOW=""
+export ICON_WIFI=""

--- a/sketchybar/.config/sketchybar/plugins/battery.sh
+++ b/sketchybar/.config/sketchybar/plugins/battery.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Battery percentage with a charge-level icon; bolt while on AC power.
+# Icon is tinted green/yellow/red by charge (Xcode Dark HC palette).
+source "$CONFIG_DIR/colors.sh"
+source "$CONFIG_DIR/icons.sh"
+
+PERCENT=$(pmset -g batt | grep -Eo '[0-9]+%' | head -1 | tr -d '%')
+[ -z "$PERCENT" ] && exit 0
+
+if pmset -g batt | grep -q 'AC Power'; then
+  ICON="$ICON_BATT_CHARGING"
+else
+  case "$PERCENT" in
+    100 | 9[0-9]) ICON="$ICON_BATT_FULL" ;;
+    [6-8][0-9]) ICON="$ICON_BATT_75" ;;
+    [3-5][0-9]) ICON="$ICON_BATT_50" ;;
+    [1-2][0-9]) ICON="$ICON_BATT_25" ;;
+    *) ICON="$ICON_BATT_EMPTY" ;;
+  esac
+fi
+
+if [ "$PERCENT" -le 20 ]; then
+  COLOR="$RED"
+elif [ "$PERCENT" -le 40 ]; then
+  COLOR="$YELLOW"
+else
+  COLOR="$GREEN"
+fi
+
+sketchybar --set "$NAME" icon="$ICON" icon.color="$COLOR" label="${PERCENT}%"

--- a/sketchybar/.config/sketchybar/plugins/cc_click.sh
+++ b/sketchybar/.config/sketchybar/plugins/cc_click.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Open a Control Center popover by clicking the menu bar item whose description
+# starts with $1 (e.g. "Wi" for Wi‑Fi, "Battery", or "Control" for the full
+# Control Center). macOS renders "Wi‑Fi" with a non-breaking hyphen, so match
+# on a prefix. The prefix is passed to AppleScript as an argument to avoid any
+# quoting/interpolation issues.
+#
+# Requires sketchybar to have Accessibility + Automation (System Events)
+# permission, since this drives the menu bar via Apple Events.
+osascript - "$1" <<'EOF'
+on run argv
+  set prefix to item 1 of argv
+  tell application "System Events"
+    tell process "ControlCenter"
+      click (first menu bar item of menu bar 1 whose description starts with prefix)
+    end tell
+  end tell
+end run
+EOF

--- a/sketchybar/.config/sketchybar/plugins/clock.sh
+++ b/sketchybar/.config/sketchybar/plugins/clock.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+sketchybar --set "$NAME" label="$(date '+%a %b %-d %-l:%M %p')"

--- a/sketchybar/.config/sketchybar/plugins/front_app.sh
+++ b/sketchybar/.config/sketchybar/plugins/front_app.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Shows the focused application's name. On a front_app_switched event the name
+# arrives in $INFO; on first paint we fall back to querying yabai.
+if [ "$SENDER" = "front_app_switched" ]; then
+  sketchybar --set "$NAME" label="$INFO"
+else
+  APP=$(yabai -m query --windows --window 2>/dev/null | jq -r '.app // empty')
+  [ -n "$APP" ] && sketchybar --set "$NAME" label="$APP"
+fi

--- a/sketchybar/.config/sketchybar/plugins/space.sh
+++ b/sketchybar/.config/sketchybar/plugins/space.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Highlights the active space. $SELECTED is set by the space_change event.
+source "$CONFIG_DIR/colors.sh"
+
+if [ "$SELECTED" = "true" ]; then
+  sketchybar --set "$NAME" background.color="$ACTIVE" icon.color="$BLACK"
+else
+  sketchybar --set "$NAME" background.color="$ITEM_BG" icon.color="$GREY"
+fi

--- a/sketchybar/.config/sketchybar/plugins/space_windows.sh
+++ b/sketchybar/.config/sketchybar/plugins/space_windows.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Paints the app icons of each space's windows into that space's label, using
+# the sketchybar-app-font ligatures (":ghostty:" etc.). Spaces with no windows
+# hide their label so they stay a clean, centered number.
+source "$CONFIG_DIR/icon_map.sh"
+
+args=()
+for sid in $(yabai -m query --spaces | jq -r '.[].index'); do
+  # Only real, standard app windows — excludes background/menu-bar apps
+  # (Granola, Tailscale, etc.) whose helper windows have a non-standard subrole.
+  apps=$(yabai -m query --windows --space "$sid" \
+    | jq -r '.[]
+        | select(.["is-minimized"]==false)
+        | select(.subrole=="AXStandardWindow")
+        | .app')
+
+  if [ -n "$apps" ]; then
+    strip=""
+    while IFS= read -r app; do
+      __icon_map "$app"
+      # Local overrides for apps whose default glyph we don't want.
+      case "$app" in
+        "Ghostty") icon_result=":terminal:" ;;
+      esac
+      strip+=" ${icon_result}"
+    done <<<"$apps"
+    strip="${strip# }" # drop the leading space so the gap to the number is even
+    args+=(--set space."$sid" label="$strip" label.drawing=on)
+  else
+    args+=(--set space."$sid" label.drawing=off)
+  fi
+done
+
+sketchybar -m "${args[@]}" >/dev/null 2>&1

--- a/sketchybar/.config/sketchybar/plugins/tailscale.sh
+++ b/sketchybar/.config/sketchybar/plugins/tailscale.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Tailscale status. When the backend is running: green logo + the tailnet name
+# (the network, not this machine), with a leading ↗ when an exit node is active
+# (mirrors Tailscale's own menu bar). Grey "off" when not running.
+source "$CONFIG_DIR/colors.sh"
+
+TS="/usr/local/bin/tailscale"
+[ -x "$TS" ] || TS="$(command -v tailscale 2>/dev/null)"
+[ -x "$TS" ] || {
+  sketchybar --set "$NAME" icon=":tailscale:" label="n/a" icon.color="$GREY"
+  exit 0
+}
+
+json=$("$TS" status --json 2>/dev/null)
+state=$(printf '%s' "$json" | jq -r '.BackendState // "Stopped"')
+tailnet=$(printf '%s' "$json" | jq -r '.CurrentTailnet.Name // empty')
+exit_active=$(printf '%s' "$json" |
+  jq -r 'if (.ExitNodeStatus != null) or (any(.Peer[]?; .ExitNode == true)) then "1" else "" end')
+
+if [ "$state" = "Running" ]; then
+  label="${tailnet:-on}"
+  [ -n "$exit_active" ] && label="↗ $label"
+  color="$GREEN"
+else
+  label="off"
+  color="$GREY"
+fi
+
+sketchybar --set "$NAME" icon=":tailscale:" label="$label" icon.color="$color"

--- a/sketchybar/.config/sketchybar/plugins/tailscale_click.sh
+++ b/sketchybar/.config/sketchybar/plugins/tailscale_click.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Open the Tailscale menu bar status menu (its dropdown lives in menu bar 2).
+# Requires sketchybar to have Accessibility + Automation permission.
+osascript <<'EOF'
+tell application "System Events"
+  tell process "Tailscale"
+    click menu bar item 1 of menu bar 2
+  end tell
+end tell
+EOF

--- a/sketchybar/.config/sketchybar/plugins/volume.sh
+++ b/sketchybar/.config/sketchybar/plugins/volume.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Volume level with a speaker icon. On a volume_change event the level is in
+# $INFO; otherwise query the current output volume.
+source "$CONFIG_DIR/icons.sh"
+
+VOLUME="${INFO:-$(osascript -e 'output volume of (get volume settings)')}"
+
+case "$VOLUME" in
+  [6-9][0-9] | 100) ICON="$ICON_VOL_HIGH" ;;
+  [3-5][0-9]) ICON="$ICON_VOL_MID" ;;
+  [1-9] | [1-2][0-9]) ICON="$ICON_VOL_LOW" ;;
+  *) ICON="$ICON_VOL_LOW" ;;
+esac
+
+sketchybar --set "$NAME" icon="$ICON" label="${VOLUME}%"

--- a/sketchybar/.config/sketchybar/plugins/wifi.sh
+++ b/sketchybar/.config/sketchybar/plugins/wifi.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Current Wi-Fi SSID, or "off" when not connected.
+#
+# Recent macOS redacts the SSID (returns the literal "<redacted>") from
+# networksetup/ipconfig unless the caller holds Location Services access.
+# system_profiler still reports it in the clear, so read it from there. It is
+# slower, but this item only refreshes every 60s.
+source "$CONFIG_DIR/colors.sh"
+source "$CONFIG_DIR/icons.sh"
+
+SSID=$(system_profiler SPAirPortDataType 2>/dev/null |
+  awk '/Current Network Information:/{getline; gsub(/^[[:space:]]+|:[[:space:]]*$/, ""); print; exit}')
+
+if [ -n "$SSID" ]; then
+  sketchybar --set "$NAME" icon="$ICON_WIFI" label="$SSID" icon.color="$CYAN"
+else
+  sketchybar --set "$NAME" icon="$ICON_WIFI" label="off" icon.color="$GREY"
+fi

--- a/sketchybar/.config/sketchybar/sketchybarrc
+++ b/sketchybar/.config/sketchybar/sketchybarrc
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+
+# yabai-integrated SketchyBar, themed to match Xcode Dark HC.
+# Left:  yabai spaces + focused app.  Right: clock, battery, volume, wifi.
+
+CONFIG_DIR="$HOME/.config/sketchybar"
+PLUGIN_DIR="$CONFIG_DIR/plugins"
+source "$CONFIG_DIR/colors.sh"
+source "$CONFIG_DIR/icons.sh"
+
+# The native macOS system font (San Francisco) — the exact face the stock menu
+# bar uses. ".AppleSystemUIFont" is the only reliably-resolving name without
+# installing Apple's SF Pro package; "SF Pro"/"System Font"/".SF NS" either fail
+# or fall back to Times New Roman. Symbols Nerd Font supplies the status glyphs;
+# app icons use sketchybar-app-font.
+FONT=".AppleSystemUIFont"
+ICON_FONT="Symbols Nerd Font"
+
+##### Bar #####
+sketchybar --bar height=32 \
+                 position=top \
+                 color="$BAR_COLOR" \
+                 padding_left=10 \
+                 padding_right=10 \
+                 sticky=on \
+                 blur_radius=20
+
+##### Defaults applied to every item #####
+sketchybar --default updates=when_shown \
+                     icon.font="$FONT:Bold:14.0" \
+                     icon.color="$WHITE" \
+                     icon.padding_left=8 \
+                     icon.padding_right=4 \
+                     label.font="$FONT:Semibold:13.0" \
+                     label.color="$WHITE" \
+                     label.padding_left=4 \
+                     label.padding_right=8 \
+                     background.color="$ITEM_BG" \
+                     background.corner_radius=6 \
+                     background.height=24 \
+                     padding_left=4 \
+                     padding_right=4
+
+##### Spaces — one item per real yabai space #####
+for sid in $(yabai -m query --spaces | jq -r '.[].index'); do
+  sketchybar --add space space."$sid" left \
+             --set space."$sid" associated_space="$sid" \
+                                icon="$sid" \
+                                icon.font=".AppleSystemUIFont:Semibold:14.0" \
+                                label.font="sketchybar-app-font:Regular:15.0" \
+                                label.drawing=off \
+                                script="$PLUGIN_DIR/space.sh" \
+                                click_script="yabai -m space --focus $sid" \
+             --subscribe space."$sid" space_change
+done
+
+# Hidden listener that repaints every space's app icons. yabai triggers the
+# custom window_change event on window create/destroy/move (see .yabairc).
+sketchybar --add event window_change
+sketchybar --add item space_windows left \
+           --set space_windows drawing=off \
+                               updates=on \
+                               script="$PLUGIN_DIR/space_windows.sh" \
+           --subscribe space_windows window_change space_change front_app_switched
+
+##### Focused application #####
+sketchybar --add item front_app left \
+           --set front_app icon.drawing=off \
+                           label.font="$FONT:Semibold:13.0" \
+                           background.drawing=off \
+                           script="$PLUGIN_DIR/front_app.sh" \
+           --subscribe front_app front_app_switched
+
+##### Right side #####
+sketchybar --add item clock right \
+           --set clock update_freq=10 \
+                       icon="$ICON_CLOCK" \
+                       icon.font="$ICON_FONT:Regular:16.0" \
+                       icon.color="$PURPLE" \
+                       click_script="open -a Calendar" \
+                       script="$PLUGIN_DIR/clock.sh" \
+           --subscribe clock system_woke
+
+sketchybar --add item battery right \
+           --set battery update_freq=120 \
+                         icon.font="$ICON_FONT:Regular:16.0" \
+                         click_script="$PLUGIN_DIR/cc_click.sh Battery" \
+                         script="$PLUGIN_DIR/battery.sh" \
+           --subscribe battery power_source_change system_woke
+
+sketchybar --add item volume right \
+           --set volume icon.font="$ICON_FONT:Regular:16.0" \
+                        icon.color="$ORANGE" \
+                        click_script="$PLUGIN_DIR/cc_click.sh Sound" \
+                        script="$PLUGIN_DIR/volume.sh" \
+           --subscribe volume volume_change
+
+sketchybar --add item wifi right \
+           --set wifi update_freq=60 \
+                      icon.font="$ICON_FONT:Regular:16.0" \
+                      click_script="$PLUGIN_DIR/cc_click.sh Wi" \
+                      script="$PLUGIN_DIR/wifi.sh" \
+           --subscribe wifi wifi_change system_woke
+
+sketchybar --add item tailscale right \
+           --set tailscale update_freq=15 \
+                           icon=":tailscale:" \
+                           icon.font="sketchybar-app-font:Regular:15.0" \
+                           click_script="$PLUGIN_DIR/tailscale_click.sh" \
+                           script="$PLUGIN_DIR/tailscale.sh" \
+           --subscribe tailscale system_woke
+
+##### Render #####
+sketchybar --update

--- a/skhd-zig/.skhdrc
+++ b/skhd-zig/.skhdrc
@@ -1,0 +1,25 @@
+# Command definitions (New in skhd.zig!) - these must be defined before use.
+# {{1}}, {{2}}, ... are the positional args passed at the call site.
+.define yabai_focus : yabai -m window --focus {{1}} || yabai -m display --focus {{1}}
+.define yabai_swap : yabai -m window --swap {{1}} || (yabai -m window --display {{1}} && yabai -m display --focus {{1}})
+.define resize_window : yabai -m window --resize {{1}}:{{2}}:{{3}}
+
+# Focus windows using command definitions
+cmd - h : @yabai_focus("west")
+cmd - j : @yabai_focus("south")
+cmd - k : @yabai_focus("north")
+cmd - l : @yabai_focus("east")
+
+# Move/swap windows using command definitions
+cmd + shift - h : @yabai_swap("west")
+cmd + shift - j : @yabai_swap("south")
+cmd + shift - k : @yabai_swap("north")
+cmd + shift - l : @yabai_swap("east")
+
+# Resize windows using command definitions
+cmd + ctrl - h : @resize_window("left", "-20", "0")
+cmd + ctrl - l : @resize_window("right", "20", "0")
+
+# Switch spaces
+cmd - 1 : yabai -m space --focus 1
+cmd - 2 : yabai -m space --focus 2

--- a/yabai/.yabairc
+++ b/yabai/.yabairc
@@ -1,0 +1,60 @@
+#!/usr/bin/env sh
+
+# scripting addition
+yabai -m signal --add event=dock_did_restart action="sudo yabai --load-sa"
+sudo yabai --load-sa
+
+# global config
+yabai -m config                                 \
+    external_bar                 all:32:0       \
+    menubar_opacity              1.0            \
+    mouse_follows_focus          off            \
+    focus_follows_mouse          off            \
+    display_arrangement_order    default        \
+    window_origin_display        default        \
+    window_placement             second_child   \
+    window_insertion_point       focused        \
+    window_zoom_persist          on             \
+    window_shadow                on             \
+    skip_window_focus_animation  off            \
+    window_animation_duration    0.0            \
+    window_animation_easing      ease_out_circ  \
+    window_opacity_duration      0.0            \
+    active_window_opacity        1.0            \
+    normal_window_opacity        0.90           \
+    window_opacity               off            \
+    insert_feedback_color        0xffd75f5f     \
+    split_ratio                  0.50           \
+    split_type                   auto           \
+    auto_balance                 off            \
+    top_padding                  12             \
+    bottom_padding               12             \
+    left_padding                 12             \
+    right_padding                12             \
+    window_gap                   06             \
+    layout                       bsp            \
+    mouse_modifier               fn             \
+    mouse_action1                move           \
+    mouse_action2                resize         \
+    mouse_drop_action            swap
+
+# --- Window rules -----------------------------------------------------------
+# Float Finder file-operation progress popups (the gray copy/move/delete boxes)
+# and other Finder system dialogs instead of tiling them.
+yabai -m rule --add app="^Finder$" subrole="AXSystemDialog" manage=off
+
+# sketchybar integration: refresh space highlight on focus changes, and rebuild
+# the bar when spaces are created/destroyed so its items track yabai's spaces.
+yabai -m signal --add event=space_changed action="sketchybar --trigger space_change" 2>/dev/null
+yabai -m signal --add event=display_changed action="sketchybar --trigger space_change" 2>/dev/null
+yabai -m signal --add event=space_created action="sketchybar --reload" 2>/dev/null
+yabai -m signal --add event=space_destroyed action="sketchybar --reload" 2>/dev/null
+
+# Repaint per-space app icons when windows come, go, or move between spaces.
+yabai -m signal --add event=window_created action="sketchybar --trigger window_change" 2>/dev/null
+yabai -m signal --add event=window_destroyed action="sketchybar --trigger window_change" 2>/dev/null
+yabai -m signal --add event=window_moved action="sketchybar --trigger window_change" 2>/dev/null
+yabai -m signal --add event=application_launched action="sketchybar --trigger window_change" 2>/dev/null
+yabai -m signal --add event=application_terminated action="sketchybar --trigger window_change" 2>/dev/null
+
+echo "yabai configuration loaded.."


### PR DESCRIPTION
## Summary
- Adds macOS window-management dotfiles and wires bootstrap so a fresh setup installs and stows them correctly.

## Changes
- Adds SketchyBar config and plugins, yabai config, and skhd-zig hotkeys.
- Renames the skhd package folder to skhd-zig.
- Marks sketchybar, skhd-zig, and yabai as macOS-only stow packages.
- Taps the required Homebrew formula repos and installs sketchybar, skhd, yabai, and font-sketchybar-app-font.
- Applies the Control Center sound menu-bar defaults used by the SketchyBar volume click script.