### PR TITLE
fix(git): prefer ssh for personal GitHub remotes

### DIFF
--- a/git/.config/git/config
+++ b/git/.config/git/config
@@ -37,5 +37,10 @@ ff = only
 	helper =
 	helper = !gh auth git-credential
 
+[url "git@github.com:tractorbeamai/"]
+	insteadOf = https://github.com/tractorbeamai/
+[url "git@github.com:wadefletch/"]
+	insteadOf = https://github.com/wadefletch/
+
 [includeIf "gitdir:~/Developer/Tractorbeam/client-carlyle/"]
 	path = ~/.config/git/gitconfig-carlyle


### PR DESCRIPTION
## Summary
- Rewrite Tractorbeam and wadefletch GitHub HTTPS remotes to SSH.
- Keep unrelated GitHub HTTPS URLs on the existing gh credential-helper path for multi-account workflows.
- Preserve SSH remotes as the reliable path for agent forwarding and SSH commit signing.