### PR TITLE
chore(codex): document approval sandbox defaults

### DIFF
--- a/codex/.codex/config.toml.reference
+++ b/codex/.codex/config.toml.reference
@@ -1,0 +1,6 @@
+approval_policy = "on-request"
+approvals_reviewer = "auto_review"
+sandbox_mode = "workspace-write"
+
+[sandbox_workspace_write]
+network_access = true


### PR DESCRIPTION
## Summary
- Add a sanitized Codex `config.toml.reference` for the approval/sandbox defaults.
- Capture auto-review approvals with workspace-write sandboxing and command network access enabled.
