### PR TITLE
fix(sketchybar): install Symbols Nerd Font, fix space race, hide desktop battery

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -18,7 +18,9 @@ MACOS_TAPS=(felixkratz/formulae koekeishiya/formulae)
 PACKAGES=(git neovim stow zsh)
 
 # macOS apps and fonts (brew casks)
-CASKS=(cursor ghostty font-sketchybar-app-font)
+# font-sketchybar-app-font renders SketchyBar's per-app icons; font-symbols-only-nerd-font
+# (family "Symbols Nerd Font") supplies the status glyphs (clock, wifi, battery, volume).
+CASKS=(cursor ghostty font-sketchybar-app-font font-symbols-only-nerd-font)
 
 info()  { printf '  [ .. ] %s\n' "$1"; }
 ok()    { printf '  [ OK ] %s\n' "$1"; }

--- a/sketchybar/.config/sketchybar/plugins/battery.sh
+++ b/sketchybar/.config/sketchybar/plugins/battery.sh
@@ -6,7 +6,12 @@ source "$CONFIG_DIR/colors.sh"
 source "$CONFIG_DIR/icons.sh"
 
 PERCENT=$(pmset -g batt | grep -Eo '[0-9]+%' | head -1 | tr -d '%')
-[ -z "$PERCENT" ] && exit 0
+# Desktops report no battery percentage. Hide the item entirely so it doesn't
+# render as an empty rounded box between volume and the clock.
+if [ -z "$PERCENT" ]; then
+  sketchybar --set "$NAME" drawing=off
+  exit 0
+fi
 
 if pmset -g batt | grep -q 'AC Power'; then
   ICON="$ICON_BATT_CHARGING"
@@ -28,4 +33,4 @@ else
   COLOR="$GREEN"
 fi
 
-sketchybar --set "$NAME" icon="$ICON" icon.color="$COLOR" label="${PERCENT}%"
+sketchybar --set "$NAME" drawing=on icon="$ICON" icon.color="$COLOR" label="${PERCENT}%"

--- a/yabai/.yabairc
+++ b/yabai/.yabairc
@@ -63,4 +63,12 @@ yabai -m signal --add event=window_moved action="sketchybar --trigger window_cha
 yabai -m signal --add event=application_launched action="sketchybar --trigger window_change" 2>/dev/null
 yabai -m signal --add event=application_terminated action="sketchybar --trigger window_change" 2>/dev/null
 
+# Rebuild sketchybar now that yabai is fully loaded and its spaces are
+# queryable. sketchybarrc enumerates spaces via `yabai -m query --spaces` at
+# load time, so when launchd starts sketchybar before yabai at login that loop
+# comes up empty and no per-space items are ever created. Reloading here closes
+# that race from the yabai side (no-op if sketchybar isn't up yet, in which case
+# sketchybar starts later with yabai already running and builds spaces itself).
+sketchybar --reload 2>/dev/null
+
 echo "yabai configuration loaded.."


### PR DESCRIPTION
## Summary
Fixes three SketchyBar issues surfaced setting up the bar on a fresh multi-monitor desktop (arrakis). None were a font corruption — the app-icon font was fine all along.

## Changes
- **bootstrap:** add `font-symbols-only-nerd-font` to `CASKS`. `sketchybarrc` uses the `Symbols Nerd Font` family for status glyphs (clock/wifi/battery/volume); without it Core Text falls back to Helvetica and they render as `?`.
- **yabai:** `sketchybar --reload` at the end of `.yabairc`. `sketchybarrc` enumerates spaces via `yabai -m query --spaces` at load time, so when launchd starts sketchybar before yabai at login the per-space items are never created. Reloading from yabai's side closes the race (no-op if sketchybar isn't up yet, in which case it starts later with yabai already running).
- **battery:** hide the item when `pmset` reports no battery, so desktops don't draw an empty rounded box between volume and the clock.

## Test Plan
- [ ] On a fresh machine, run `bootstrap.sh` and confirm status glyphs render (no `?`).
- [ ] Reboot and confirm per-space items populate regardless of sketchybar/yabai launch order.