### PR TITLE
fix(skhd,yabai): pass cmd+shift+l to Dia for Bitwarden, drop popout sizing

### DIFF
--- a/skhd-zig/.skhdrc
+++ b/skhd-zig/.skhdrc
@@ -14,7 +14,11 @@ cmd - l : @yabai_focus("east")
 cmd + shift - h : @yabai_swap("west")
 cmd + shift - j : @yabai_swap("south")
 cmd + shift - k : @yabai_swap("north")
-cmd + shift - l : @yabai_swap("east")
+# Pass cmd+shift+l through to Dia (Bitwarden autofill); swap east everywhere else.
+cmd + shift - l [
+    "dia" ~
+    *     : @yabai_swap("east")
+]
 
 # Resize windows using command definitions
 cmd + ctrl - h : @resize_window("left", "-20", "0")

--- a/yabai/.yabairc
+++ b/yabai/.yabairc
@@ -43,11 +43,10 @@ yabai -m config                                 \
 # and other Finder system dialogs instead of tiling them.
 yabai -m rule --add app="^Finder$" subrole="AXSystemDialog" manage=off
 
-# Float + center the Bitwarden extension popout window. It shares the browser's
-# app name and looks like AXStandardWindow, so the window title (which equals the
-# extension name) is the only discriminator.
-# grid=rows:cols:x:y:w:h places a centered box; tune w:h to resize.
-yabai -m rule --add app="^(Dia|Arc|Google Chrome)$" title="^Bitwarden$" manage=off grid=9:9:3:2:3:5
+# Float the Bitwarden extension popout window (leave its size/position alone). It
+# shares the browser's app name and looks like AXStandardWindow, so the window
+# title (which equals the extension name) is the only discriminator.
+yabai -m rule --add app="^(Dia|Arc|Google Chrome)$" title="^Bitwarden$" manage=off
 
 # sketchybar integration: refresh space highlight on focus changes, and rebuild
 # the bar when spaces are created/destroyed so its items track yabai's spaces.


### PR DESCRIPTION
## Summary
- `cmd+shift+l` (Dia's Bitwarden autofill shortcut) was being swallowed by skhd's `yabai_swap("east")` binding. When no window sat east of the focused one, the `||` fallback in the `yabai_swap` macro ran `yabai -m window --display east`, flinging the whole Dia window onto another screen instead of letting Dia handle the keystroke.
- Now `cmd+shift+l` passes through to Dia (via skhd.zig's per-app `~` unbind) so Bitwarden autofill fires, while still swapping east in every other app.
- Also drops the forced `grid=9:9:3:2:3:5` placement on the Bitwarden popout rule so it just floats at its native size/position.

## Changes
- `skhd-zig/.skhdrc`: make `cmd+shift+l` app-aware — unbind for Dia, `@yabai_swap("east")` for `*`.
- `yabai/.yabairc`: remove `grid=...` from the Bitwarden popout rule, keeping `manage=off`.