### PR TITLE
feat(yabai,skhd): ctrl-leader keymap and Ghostty native-tab fix

### DIFF
--- a/skhd-zig/.skhdrc
+++ b/skhd-zig/.skhdrc
@@ -1,29 +1,38 @@
-# Command definitions (New in skhd.zig!) - these must be defined before use.
+# Command definitions - these must be defined before use.
 # {{1}}, {{2}}, ... are the positional args passed at the call site.
 .define yabai_focus : yabai -m window --focus {{1}} || yabai -m display --focus {{1}}
 .define yabai_swap : yabai -m window --swap {{1}} || (yabai -m window --display {{1}} && yabai -m display --focus {{1}})
-.define resize_window : yabai -m window --resize {{1}}:{{2}}:{{3}}
+# Resize by expand/contract along an axis. Which physical edge moves is a
+# product of the bsp layout: try the primary handle, and if it has no fence
+# (e.g. it's a screen boundary, exit 1), fall back to the opposite handle with
+# the sign flipped so the grow/shrink direction is preserved either way.
+.define resize : yabai -m window --resize {{1}} || yabai -m window --resize {{2}}
 
 # Focus windows using command definitions
-cmd - h : @yabai_focus("west")
-cmd - j : @yabai_focus("south")
-cmd - k : @yabai_focus("north")
-cmd - l : @yabai_focus("east")
+ctrl - h : @yabai_focus("west")
+ctrl - j : @yabai_focus("south")
+ctrl - k : @yabai_focus("north")
+ctrl - l : @yabai_focus("east")
 
 # Move/swap windows using command definitions
-cmd + shift - h : @yabai_swap("west")
-cmd + shift - j : @yabai_swap("south")
-cmd + shift - k : @yabai_swap("north")
-# Pass cmd+shift+l through to Dia (Bitwarden autofill); swap east everywhere else.
-cmd + shift - l [
-    "dia" ~
-    *     : @yabai_swap("east")
-]
+ctrl + shift - h : @yabai_swap("west")
+ctrl + shift - j : @yabai_swap("south")
+ctrl + shift - k : @yabai_swap("north")
+ctrl + shift - l : @yabai_swap("east")
 
-# Resize windows using command definitions
-cmd + ctrl - h : @resize_window("left", "-20", "0")
-cmd + ctrl - l : @resize_window("right", "20", "0")
+# Resize windows: h/l contract/expand width, k/j contract/expand height.
+ctrl + alt - h : @resize("right:-20:0", "left:20:0")
+ctrl + alt - l : @resize("right:20:0", "left:-20:0")
+ctrl + alt - k : @resize("bottom:0:-20", "top:0:20")
+ctrl + alt - j : @resize("bottom:0:20", "top:0:-20")
 
 # Switch spaces
-cmd - 1 : yabai -m space --focus 1
-cmd - 2 : yabai -m space --focus 2
+ctrl - 1 : yabai -m space --focus 1
+ctrl - 2 : yabai -m space --focus 2
+ctrl - 3 : yabai -m space --focus 3
+ctrl - 4 : yabai -m space --focus 4
+ctrl - 5 : yabai -m space --focus 5
+ctrl - 6 : yabai -m space --focus 6
+ctrl - 7 : yabai -m space --focus 7
+ctrl - 8 : yabai -m space --focus 8
+ctrl - 9 : yabai -m space --focus 9

--- a/yabai/.yabairc
+++ b/yabai/.yabairc
@@ -11,7 +11,7 @@ yabai -m config                                 \
     mouse_follows_focus          off            \
     focus_follows_mouse          off            \
     display_arrangement_order    default        \
-    window_origin_display        default        \
+    window_origin_display        focused        \
     window_placement             second_child   \
     window_insertion_point       focused        \
     window_zoom_persist          on             \
@@ -47,6 +47,15 @@ yabai -m rule --add app="^Finder$" subrole="AXSystemDialog" manage=off
 # shares the browser's app name and looks like AXStandardWindow, so the window
 # title (which equals the extension name) is the only discriminator.
 yabai -m rule --add app="^(Dia|Arc|Google Chrome)$" title="^Bitwarden$" manage=off
+
+# Ghostty native macOS tabs: macOS exposes each AppKit tab as a separate window
+# to the Accessibility API, so yabai tiles every new tab into a split. There is
+# no fix on either project's side (confirmed by both maintainers). Ghostty's
+# official workaround (ghostty.org/docs/help/macos-tiling-wms) re-applies the bsp
+# layout whenever Ghostty creates/destroys a window, collapsing the spurious
+# split back down. Expect a brief flash on new-tab.
+yabai -m signal --add app="^Ghostty$" event=window_created action="yabai -m space --layout bsp"
+yabai -m signal --add app="^Ghostty$" event=window_destroyed action="yabai -m space --layout bsp"
 
 # sketchybar integration: refresh space highlight on focus changes, and rebuild
 # the bar when spaces are created/destroyed so its items track yabai's spaces.


### PR DESCRIPTION
## Summary
- Move the yabai/skhd window-management keymap from the `cmd` leader to `ctrl`, so it stops swallowing app shortcuts in Superhuman/Dia (which share a process): `cmd-k` command palette, `cmd-t` new tab, `cmd-shift-l` Bitwarden autofill.
- Fix yabai tiling Ghostty's native macOS tabs into a split — macOS exposes each AppKit tab as its own window, so yabai now re-applies the bsp layout on Ghostty window create/destroy (Ghostty's official tiling-WM workaround).

## Changes
- **yabai**: `window_origin_display` `default` → `focused` so new windows spawn on the focused display instead of jumping screens.
- **yabai**: add `window_created`/`window_destroyed` signals for Ghostty that re-run `space --layout bsp`.
- **skhd**: focus `ctrl - hjkl`, swap `ctrl+shift - hjkl`, resize `ctrl+alt - hjkl`, spaces `ctrl - 1..9`.
- **skhd**: resize is now layout-aware expand/contract — tries the internal handle, falls back to the opposite edge (with sign flipped) so grow/shrink direction is preserved regardless of the window's position in the split.
- **skhd**: drop the now-unneeded Superhuman/Dia passthrough hacks; with `cmd` free, those app shortcuts pass through natively.

## Test Plan
- [ ] Open a new tab in Ghostty — it should stay a tab, not split the pane.
- [ ] In Superhuman/Dia, confirm `cmd-k`, `cmd-t`, `cmd-shift-l` work.
- [ ] Note: `ctrl-hjkl` now shadows terminal/readline keys (clear-screen, kill-line, etc.) inside Ghostty.