### PR TITLE
chore(ssh): add charlie host over Tailscale

### DIFF
--- a/ssh/.ssh/config
+++ b/ssh/.ssh/config
@@ -21,3 +21,10 @@ Host corrino
   ForwardAgent yes
   IdentityFile ~/.ssh/id_github_wadefletch
 
+# Charlie's MacBook Air (Tailscale). Native sshd support access.
+# No ForwardAgent — don't expose the local agent to another user's machine.
+Host charlie
+  HostName charlies-macbook-air.end-artichoke.ts.net
+  User charliebrizz
+  IdentityFile ~/.ssh/id_github_wadefletch
+


### PR DESCRIPTION
## Summary
- Add an SSH `charlie` host entry for Charlie's MacBook Air, reachable over Tailscale MagicDNS.

## Changes
- New `Host charlie` block (`User charliebrizz`, Tailscale hostname, github identity file).
- No `ForwardAgent` — deliberately avoids exposing the local agent to another user's machine.