### PR TITLE
chore(claude): enable legal-docs plugin

### DIFF
--- a/claude/.claude/settings.json
+++ b/claude/.claude/settings.json
@@ -322,6 +322,7 @@
     "document-skills@anthropic-agent-skills": false,
     "rust-analyzer-lsp@claude-plugins-official": true,
     "documents@tractorbeam": false,
+    "legal-docs@tractorbeam": true,
     "shadcn@shadcn-ui": true,
     "figma@claude-plugins-official": true
   },
@@ -358,13 +359,13 @@
       }
     }
   },
+  "showClearContextOnPlanAccept": true,
   "autoUpdatesChannel": "latest",
   "autoMemoryEnabled": false,
   "skipDangerousModePermissionPrompt": true,
   "theme": "auto",
   "verbose": true,
   "preferredNotifChannel": "ghostty",
-  "skipAutoPermissionPrompt": true,
   "agentPushNotifEnabled": true,
-  "showClearContextOnPlanAccept": true
+  "skipAutoPermissionPrompt": true
 }


### PR DESCRIPTION
## Summary
- Enable the `legal-docs@tractorbeam` Claude Code plugin.

## Changes
- `legal-docs@tractorbeam` set to `true` in `enabledPlugins`.
- Minor reordering of top-level settings keys (no behavior change).