### PR TITLE
feat(factory): add Factory Droid plugin configuration

### DIFF
--- a/factory/README.md
+++ b/factory/README.md
@@ -1,0 +1,45 @@
+# Factory Droid Configuration
+
+Plugin configuration for [Factory Droid](https://factory.ai).
+
+## Files
+
+- `plugins/installed_plugins.json` - Installed plugins and their versions
+- `plugins/known_marketplaces.json` - Registered plugin marketplaces
+
+## Installed Plugins
+
+### Factory Official
+- `core@factory-plugins` - Core review and simplify skills
+- `droid-control@factory-plugins` - Terminal, browser, and desktop automation
+
+### Tractorbeam Skills
+- `code-style@skills` - Linting, formatting, testing, and comment conventions
+- `git@skills` - Git workflows (commits, PRs, conflicts)
+- `linear@skills` - Linear integration skill
+- `references@skills` - Reference documentation skill
+- `reflect@skills` - Session reflection and improvement
+- `documents@skills` - Document management skill
+- `mise@skills` - Mise tool version management
+- `team-kit@skills` - Team collaboration tools
+- `legal-docs@skills` - Legal document organization
+
+## Setup
+
+Symlinks are created by `bootstrap.sh`:
+```bash
+ln -sf ~/.dotfiles/factory/plugins/installed_plugins.json ~/.factory/plugins/
+ln -sf ~/.dotfiles/factory/plugins/known_marketplaces.json ~/.factory/plugins/
+```
+
+## Adding New Plugins
+
+```bash
+# Add a marketplace
+droid plugin marketplace add https://github.com/owner/repo
+
+# Install a plugin
+droid plugin install -s user plugin-name@marketplace
+```
+
+The plugin configs will automatically update in this dotfiles directory via symlinks.

--- a/factory/plugins/installed_plugins.json
+++ b/factory/plugins/installed_plugins.json
@@ -1,0 +1,115 @@
+{
+  "schemaVersion": 1,
+  "plugins": {
+    "core@factory-plugins": [
+      {
+        "scope": "user",
+        "installPath": "/Users/wadefletcher/.factory/plugins/cache/factory-plugins/core/0c10b397a80c",
+        "version": "0c10b397a80c",
+        "installedAt": "2026-06-24T03:19:14.297Z",
+        "lastUpdated": "2026-06-24T03:19:14.297Z",
+        "source": "factory-plugins"
+      }
+    ],
+    "droid-control@factory-plugins": [
+      {
+        "scope": "user",
+        "installPath": "/Users/wadefletcher/.factory/plugins/cache/factory-plugins/droid-control/0c10b397a80c",
+        "version": "0c10b397a80c",
+        "installedAt": "2026-06-24T03:19:14.688Z",
+        "lastUpdated": "2026-06-24T03:19:14.688Z",
+        "source": "factory-plugins"
+      }
+    ],
+    "code-style@skills": [
+      {
+        "scope": "user",
+        "installPath": "/Users/wadefletcher/.factory/plugins/cache/skills/code-style/a35962f148f4",
+        "version": "a35962f148f4",
+        "installedAt": "2026-06-24T03:58:13.590Z",
+        "lastUpdated": "2026-06-24T03:58:13.590Z",
+        "source": "skills"
+      }
+    ],
+    "git@skills": [
+      {
+        "scope": "user",
+        "installPath": "/Users/wadefletcher/.factory/plugins/cache/skills/git/a35962f148f4",
+        "version": "a35962f148f4",
+        "installedAt": "2026-06-24T03:58:15.552Z",
+        "lastUpdated": "2026-06-24T03:58:15.552Z",
+        "source": "skills"
+      }
+    ],
+    "linear@skills": [
+      {
+        "scope": "user",
+        "installPath": "/Users/wadefletcher/.factory/plugins/cache/skills/linear/a35962f148f4",
+        "version": "a35962f148f4",
+        "installedAt": "2026-06-24T03:58:17.538Z",
+        "lastUpdated": "2026-06-24T03:58:17.538Z",
+        "source": "skills"
+      }
+    ],
+    "references@skills": [
+      {
+        "scope": "user",
+        "installPath": "/Users/wadefletcher/.factory/plugins/cache/skills/references/a35962f148f4",
+        "version": "a35962f148f4",
+        "installedAt": "2026-06-24T03:58:19.665Z",
+        "lastUpdated": "2026-06-24T03:58:19.665Z",
+        "source": "skills"
+      }
+    ],
+    "reflect@skills": [
+      {
+        "scope": "user",
+        "installPath": "/Users/wadefletcher/.factory/plugins/cache/skills/reflect/a35962f148f4",
+        "version": "a35962f148f4",
+        "installedAt": "2026-06-24T03:58:21.618Z",
+        "lastUpdated": "2026-06-24T03:58:21.618Z",
+        "source": "skills"
+      }
+    ],
+    "documents@skills": [
+      {
+        "scope": "user",
+        "installPath": "/Users/wadefletcher/.factory/plugins/cache/skills/documents/a35962f148f4",
+        "version": "a35962f148f4",
+        "installedAt": "2026-06-24T03:58:23.419Z",
+        "lastUpdated": "2026-06-24T03:58:23.419Z",
+        "source": "skills"
+      }
+    ],
+    "mise@skills": [
+      {
+        "scope": "user",
+        "installPath": "/Users/wadefletcher/.factory/plugins/cache/skills/mise/a35962f148f4",
+        "version": "a35962f148f4",
+        "installedAt": "2026-06-24T03:58:25.461Z",
+        "lastUpdated": "2026-06-24T03:58:25.461Z",
+        "source": "skills"
+      }
+    ],
+    "team-kit@skills": [
+      {
+        "scope": "user",
+        "installPath": "/Users/wadefletcher/.factory/plugins/cache/skills/team-kit/a35962f148f4",
+        "version": "a35962f148f4",
+        "installedAt": "2026-06-24T03:58:27.669Z",
+        "lastUpdated": "2026-06-24T03:58:27.669Z",
+        "source": "skills"
+      }
+    ],
+    "legal-docs@skills": [
+      {
+        "scope": "user",
+        "installPath": "/Users/wadefletcher/.factory/plugins/cache/skills/legal-docs/a35962f148f4",
+        "version": "a35962f148f4",
+        "installedAt": "2026-06-24T03:58:30.009Z",
+        "lastUpdated": "2026-06-24T03:58:30.009Z",
+        "source": "skills"
+      }
+    ]
+  }
+}

--- a/factory/plugins/known_marketplaces.json
+++ b/factory/plugins/known_marketplaces.json
@@ -1,0 +1,20 @@
+{
+  "factory-plugins": {
+    "source": {
+      "source": "github",
+      "repo": "Factory-AI/factory-plugins"
+    },
+    "installLocation": "/Users/wadefletcher/.factory/plugins/marketplaces/factory-plugins",
+    "lastUpdated": "2026-06-24T03:37:18.585Z",
+    "autoUpdate": true
+  },
+  "skills": {
+    "source": {
+      "source": "github",
+      "repo": "tractorbeamai/skills"
+    },
+    "installLocation": "/Users/wadefletcher/.factory/plugins/marketplaces/skills",
+    "lastUpdated": "2026-06-24T03:57:59.642Z",
+    "autoUpdate": true
+  }
+}


### PR DESCRIPTION
## Summary
- Adds Factory Droid plugin configuration to dotfiles
- Enables dual compatibility with existing Claude Code plugins
- All Tractorbeam skills now work in both Claude Code and Droid

## Changes
- Created `factory/` directory with plugin configs and README
- Added `plugins/installed_plugins.json` tracking 11 installed plugins
- Added `plugins/known_marketplaces.json` with factory-plugins and tractorbeam skills marketplaces
- Plugin configs symlinked from `~/.factory/plugins/` for version control

## Installed Plugins
**Factory Official:**
- core@factory-plugins (review, simplify)
- droid-control@factory-plugins (terminal, browser, desktop automation)

**Tractorbeam Skills:**
- code-style, git, linear, references, reflect, documents, mise, team-kit, legal-docs

## Related
- tractorbeamai/skills#132 added `.factory-plugin` symlinks for dual compatibility