### PR TITLE
chore(zsh): force OSC 8 hyperlinks in Ghostty

### DIFF
--- a/zsh/.zshenv
+++ b/zsh/.zshenv
@@ -35,3 +35,12 @@ fi
 if [[ -d "$HOME/.local/bin" ]]; then
   export PATH="$HOME/.local/bin:$PATH"
 fi
+
+# Force OSC 8 terminal hyperlinks in Ghostty. Claude Code (and other
+# supports-hyperlinks-based CLIs) gate clickable links on TERM_PROGRAM, which
+# Ghostty doesn't reliably set, so markdown/PR links render as dead plain text.
+# Keyed off $TERM (reliably xterm-ghostty) rather than the missing TERM_PROGRAM.
+# See anthropics/claude-code#70423.
+if [[ "$TERM" == "xterm-ghostty" ]]; then
+  export FORCE_HYPERLINK=1
+fi


### PR DESCRIPTION
## Summary
- Markdown/PR links printed by Claude Code (and other `supports-hyperlinks`-based CLIs) render as dead plain text in Ghostty — they're never emitted as clickable OSC 8 hyperlinks.
- Root cause is upstream: Claude Code gates OSC 8 emission on `TERM_PROGRAM`, which Ghostty doesn't reliably set (it's empty in my env), so detection fails. Tracked at anthropics/claude-code#70423.
- `FORCE_HYPERLINK=1` short-circuits that detection and forces hyperlinks on. Scoped to Ghostty via `$TERM == xterm-ghostty` (the reliable signal) so it never lies to a terminal that genuinely lacks OSC 8 support.

## Changes
- `zsh/.zshenv`: export `FORCE_HYPERLINK=1` when `$TERM` is `xterm-ghostty`.

## Test Plan
- [ ] Open a fresh Ghostty shell, run `claude`, and ⌘-click a markdown link in its output — it should open in Dia (the default browser). Before this change the link is unclickable plain text.