### PR TITLE
feat(factory): add droid-control, code-style, team-kit plugins

### DIFF
--- a/factory/.factory/plugins/installed_plugins.json
+++ b/factory/.factory/plugins/installed_plugins.json
@@ -60,6 +60,36 @@
         "lastUpdated": "2026-07-01T19:06:58.915Z",
         "source": "skills"
       }
+    ],
+    "droid-control@factory-plugins": [
+      {
+        "scope": "user",
+        "installPath": "/Users/wadefletcher/.factory/plugins/cache/factory-plugins/droid-control/0c10b397a80c",
+        "version": "0c10b397a80c",
+        "installedAt": "2026-07-01T19:17:51.812Z",
+        "lastUpdated": "2026-07-01T19:17:51.812Z",
+        "source": "factory-plugins"
+      }
+    ],
+    "code-style@skills": [
+      {
+        "scope": "user",
+        "installPath": "/Users/wadefletcher/.factory/plugins/cache/skills/code-style/b839d9a3a8f9",
+        "version": "b839d9a3a8f9",
+        "installedAt": "2026-07-01T19:17:53.209Z",
+        "lastUpdated": "2026-07-01T19:17:53.209Z",
+        "source": "skills"
+      }
+    ],
+    "team-kit@skills": [
+      {
+        "scope": "user",
+        "installPath": "/Users/wadefletcher/.factory/plugins/cache/skills/team-kit/b839d9a3a8f9",
+        "version": "b839d9a3a8f9",
+        "installedAt": "2026-07-01T19:17:54.618Z",
+        "lastUpdated": "2026-07-01T19:17:54.618Z",
+        "source": "skills"
+      }
     ]
   }
 }

--- a/factory/.factory/settings.json
+++ b/factory/.factory/settings.json
@@ -8,7 +8,10 @@
     "references@skills": false,
     "reflect@skills": false,
     "documents@skills": false,
-    "mise@skills": true
+    "mise@skills": true,
+    "droid-control@factory-plugins": true,
+    "code-style@skills": true,
+    "team-kit@skills": true
   },
   "theme": "factory-light"
 }

--- a/factory/README.md
+++ b/factory/README.md
@@ -12,11 +12,14 @@ Plugin configuration for [Factory Droid](https://factory.ai).
 
 ### Factory Official
 - `core@factory-plugins` - Core review and simplify skills
+- `droid-control@factory-plugins` - Terminal, browser, and desktop automation
 
 ### Tractorbeam Skills
 - `git@skills` - Git workflows (commits, PRs, conflicts)
 - `linear@skills` - Linear integration skill
 - `terraform@skills` - Terraform conventions
+- `code-style@skills` - Linting, formatting, testing, and comment conventions
+- `team-kit@skills` - Team collaboration tools
 - `references@skills` - Reference documentation skill
 - `mise@skills` - Puts pinned mise tools on PATH for shell tool sessions
 


### PR DESCRIPTION
Reconciles the shared Factory config up to the superset used across machines.

arrakis had `droid-control`, `code-style`, and `team-kit` enabled but the tracked dotfiles didn't. This installs + enables all three so both machines converge without losing plugins. None ship hooks, so no new hooks run.