### PR TITLE
fix(factory): drop removed terraform@skills, align plugin versions

### DIFF
--- a/factory/.factory/plugins/installed_plugins.json
+++ b/factory/.factory/plugins/installed_plugins.json
@@ -1,46 +1,6 @@
 {
   "schemaVersion": 1,
   "plugins": {
-    "linear@skills": [
-      {
-        "scope": "user",
-        "installPath": "/Users/wadefletcher/.factory/plugins/cache/skills/linear/92e1424f4173",
-        "version": "92e1424f4173",
-        "installedAt": "2026-07-01T15:05:00.361Z",
-        "lastUpdated": "2026-07-01T15:05:00.361Z",
-        "source": "skills"
-      }
-    ],
-    "git@skills": [
-      {
-        "scope": "user",
-        "installPath": "/Users/wadefletcher/.factory/plugins/cache/skills/git/92e1424f4173",
-        "version": "92e1424f4173",
-        "installedAt": "2026-07-01T15:05:00.378Z",
-        "lastUpdated": "2026-07-01T15:05:00.378Z",
-        "source": "skills"
-      }
-    ],
-    "terraform@skills": [
-      {
-        "scope": "user",
-        "installPath": "/Users/wadefletcher/.factory/plugins/cache/skills/terraform/92e1424f4173",
-        "version": "92e1424f4173",
-        "installedAt": "2026-07-01T15:05:00.394Z",
-        "lastUpdated": "2026-07-01T15:05:00.394Z",
-        "source": "skills"
-      }
-    ],
-    "references@skills": [
-      {
-        "scope": "user",
-        "installPath": "/Users/wadefletcher/.factory/plugins/cache/skills/references/92e1424f4173",
-        "version": "92e1424f4173",
-        "installedAt": "2026-07-01T15:05:00.410Z",
-        "lastUpdated": "2026-07-01T15:05:00.410Z",
-        "source": "skills"
-      }
-    ],
     "core@factory-plugins": [
       {
         "scope": "user",
@@ -88,6 +48,36 @@
         "version": "b839d9a3a8f9",
         "installedAt": "2026-07-01T19:17:54.618Z",
         "lastUpdated": "2026-07-01T19:17:54.618Z",
+        "source": "skills"
+      }
+    ],
+    "git@skills": [
+      {
+        "scope": "user",
+        "installPath": "/Users/wadefletcher/.factory/plugins/cache/skills/git/b839d9a3a8f9",
+        "version": "b839d9a3a8f9",
+        "installedAt": "2026-07-01T19:23:58.425Z",
+        "lastUpdated": "2026-07-01T19:23:58.425Z",
+        "source": "skills"
+      }
+    ],
+    "linear@skills": [
+      {
+        "scope": "user",
+        "installPath": "/Users/wadefletcher/.factory/plugins/cache/skills/linear/b839d9a3a8f9",
+        "version": "b839d9a3a8f9",
+        "installedAt": "2026-07-01T19:24:08.117Z",
+        "lastUpdated": "2026-07-01T19:24:08.117Z",
+        "source": "skills"
+      }
+    ],
+    "references@skills": [
+      {
+        "scope": "user",
+        "installPath": "/Users/wadefletcher/.factory/plugins/cache/skills/references/b839d9a3a8f9",
+        "version": "b839d9a3a8f9",
+        "installedAt": "2026-07-01T19:24:17.502Z",
+        "lastUpdated": "2026-07-01T19:24:17.502Z",
         "source": "skills"
       }
     ]

--- a/factory/.factory/plugins/known_marketplaces.json
+++ b/factory/.factory/plugins/known_marketplaces.json
@@ -5,7 +5,7 @@
       "repo": "Factory-AI/factory-plugins"
     },
     "installLocation": "/Users/wadefletcher/.factory/plugins/marketplaces/factory-plugins",
-    "lastUpdated": "2026-07-01T15:05:00.340Z",
+    "lastUpdated": "2026-07-01T19:23:22.628Z",
     "autoUpdate": true
   },
   "skills": {
@@ -14,7 +14,7 @@
       "repo": "tractorbeamai/skills"
     },
     "installLocation": "/Users/wadefletcher/.factory/plugins/marketplaces/skills",
-    "lastUpdated": "2026-07-01T19:06:48.590Z",
+    "lastUpdated": "2026-07-01T19:24:12.647Z",
     "autoUpdate": true
   }
 }

--- a/factory/.factory/settings.json
+++ b/factory/.factory/settings.json
@@ -3,7 +3,6 @@
   "enabledPlugins": {
     "linear@skills": true,
     "git@skills": true,
-    "terraform@skills": true,
     "core@factory-plugins": true,
     "references@skills": false,
     "reflect@skills": false,

--- a/factory/README.md
+++ b/factory/README.md
@@ -17,8 +17,7 @@ Plugin configuration for [Factory Droid](https://factory.ai).
 ### Tractorbeam Skills
 - `git@skills` - Git workflows (commits, PRs, conflicts)
 - `linear@skills` - Linear integration skill
-- `terraform@skills` - Terraform conventions
-- `code-style@skills` - Linting, formatting, testing, and comment conventions
+- `code-style@skills` - Linting, formatting, testing, comments, and terraform
 - `team-kit@skills` - Team collaboration tools
 - `references@skills` - Reference documentation skill
 - `mise@skills` - Puts pinned mise tools on PATH for shell tool sessions


### PR DESCRIPTION
`terraform@skills` no longer exists upstream — it was folded into `code-style@skills` (`code-style/skills/terraform`), which both machines already have. Removes the dangling entry and bumps git/linear/references to the current `b839d9a` skills commit so all skills plugins pin one consistent version. This makes the tracked config match arrakis's enabled set exactly.